### PR TITLE
fix partial display of columns in GridLayout when # of components is …

### DIFF
--- a/src/main/java/com/googlecode/lanterna/gui2/GridLayout.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/GridLayout.java
@@ -365,7 +365,7 @@ public class GridLayout implements LayoutManager {
             for(int i = 0; i < actualNumberOfColumns; i++) {
                 Component component = row[i];
                 if(component == null) {
-                    columnWidths[i] = 0;
+                    //columnWidths[i] = 0;
                     continue;
                 }
                 GridLayoutData layoutData = getLayoutData(component);


### PR DESCRIPTION
…not a multiple of # of columns.

Not sure if this is the best fix, but it seems to work.

Not sure, what was the original intention behind zeroing the width of the whole column if it contains an empty cell, though.