### PR TITLE
TextImage.toString, ListBox, IOSafeExtendedTerminal

### DIFF
--- a/src/main/java/com/googlecode/lanterna/graphics/BasicTextImage.java
+++ b/src/main/java/com/googlecode/lanterna/graphics/BasicTextImage.java
@@ -230,4 +230,17 @@ public class BasicTextImage implements TextImage {
             }
         };
     }
+    
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(size.getRows()*(size.getColumns()+1)+50);
+        sb.append('{').append(size.getColumns()).append('x').append(size.getRows()).append('}').append('\n');
+        for (TextCharacter[] line : buffer) {
+            for (TextCharacter tc : line) {
+                sb.append(tc.getCharacter());
+            }
+            sb.append('\n');
+        }
+        return sb.toString();
+    }
 }

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractListBox.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractListBox.java
@@ -34,7 +34,7 @@ import java.util.List;
 public abstract class AbstractListBox<V, T extends AbstractListBox<V, T>> extends AbstractInteractableComponent<T> {
     private final List<V> items;
     private int selectedIndex;
-    private ListItemRenderer listItemRenderer;
+    private ListItemRenderer<V,T> listItemRenderer;
 
     protected AbstractListBox() {
         this(null);
@@ -52,20 +52,21 @@ public abstract class AbstractListBox<V, T extends AbstractListBox<V, T>> extend
         return new DefaultListBoxRenderer<V, T>();
     }
     
-    protected ListItemRenderer createDefaultListItemRenderer() {
-        return new ListItemRenderer();
+    protected ListItemRenderer<V,T> createDefaultListItemRenderer() {
+        return new ListItemRenderer<V,T>();
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     protected ListBoxRenderer<V, T> getRenderer() {
         return (ListBoxRenderer<V, T>)super.getRenderer();
     }
     
-    public ListItemRenderer getListItemRenderer() {
+    public ListItemRenderer<V,T> getListItemRenderer() {
         return listItemRenderer;
     }
 
-    public synchronized void setListItemRenderer(ListItemRenderer listItemRenderer) {
+    public synchronized void setListItemRenderer(ListItemRenderer<V,T> listItemRenderer) {
         if(listItemRenderer == null) {
             listItemRenderer = createDefaultListItemRenderer();
             if(listItemRenderer == null) {
@@ -242,7 +243,7 @@ public abstract class AbstractListBox<V, T extends AbstractListBox<V, T>> extend
         public TerminalSize getPreferredSize(T listBox) {
             int maxWidth = 5;   //Set it to something...
             int index = 0;
-            for (Object item : listBox.getItems()) {
+            for (V item : listBox.getItems()) {
                 String itemString = listBox.getListItemRenderer().getLabel(listBox, index++, item);
                 if (itemString.length() > maxWidth) {
                     maxWidth = itemString.length();
@@ -258,7 +259,7 @@ public abstract class AbstractListBox<V, T extends AbstractListBox<V, T>> extend
             int componentWidth = graphics.getSize().getColumns();
             int selectedIndex = listBox.getSelectedIndex();
             List<V> items = listBox.getItems();
-            ListItemRenderer listItemRenderer = listBox.getListItemRenderer();
+            ListItemRenderer<V,T> listItemRenderer = listBox.getListItemRenderer();
             pageSize = componentHeight;
 
             if(selectedIndex != -1) {
@@ -314,16 +315,16 @@ public abstract class AbstractListBox<V, T extends AbstractListBox<V, T>> extend
         }
     }
 
-    public static class ListItemRenderer {
+    public static class ListItemRenderer<V, T extends AbstractListBox<V, T>> {
         protected int getHotSpotPositionOnLine(int selectedIndex) {
             return 0;
         }
 
-        protected String getLabel(AbstractListBox<?, ?> listBox, int index, Object item) {
+        protected String getLabel(T listBox, int index, V item) {
             return item != null ? item.toString() : "<null>";
         }
 
-        protected void drawItem(TextGUIGraphics graphics, AbstractListBox<?, ?> listBox, int index, Object item, boolean selected, boolean focused) {
+        protected void drawItem(TextGUIGraphics graphics, T listBox, int index, V item, boolean selected, boolean focused) {
             if(selected && focused) {
                 graphics.applyThemeStyle(graphics.getThemeDefinition(AbstractListBox.class).getSelected());
             }

--- a/src/main/java/com/googlecode/lanterna/gui2/CheckBoxList.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/CheckBoxList.java
@@ -41,8 +41,8 @@ public class CheckBoxList<V> extends AbstractListBox<V, CheckBoxList<V>> {
     }
 
     @Override
-    protected ListItemRenderer createDefaultListItemRenderer() {
-        return new CheckBoxListItemRenderer();
+    protected ListItemRenderer<V,CheckBoxList<V>> createDefaultListItemRenderer() {
+        return new CheckBoxListItemRenderer<V>();
     }
 
     @Override
@@ -91,16 +91,16 @@ public class CheckBoxList<V> extends AbstractListBox<V, CheckBoxList<V>> {
         return super.handleKeyStroke(keyStroke);
     }
 
-    public static class CheckBoxListItemRenderer extends ListItemRenderer {
+    public static class CheckBoxListItemRenderer<V> extends ListItemRenderer<V,CheckBoxList<V>> {
         @Override
         protected int getHotSpotPositionOnLine(int selectedIndex) {
             return 1;
         }
 
         @Override
-        protected String getLabel(AbstractListBox<?, ?> listBox, int index, Object item) {
+        protected String getLabel(CheckBoxList<V> listBox, int index, V item) {
             String check = " ";
-            List<Boolean> itemStatus = ((CheckBoxList) listBox).itemStatus;
+            List<Boolean> itemStatus = listBox.itemStatus;
             if(itemStatus.get(index))
                 check = "x";
 

--- a/src/main/java/com/googlecode/lanterna/gui2/GridLayout.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/GridLayout.java
@@ -335,6 +335,8 @@ public class GridLayout implements LayoutManager {
                         case FILL:
                             size = size.withColumns(availableHorizontalSpace);
                             break;
+                        default:
+                            break;
                     }
                     switch (layoutData.verticalAlignment) {
                         case CENTER:
@@ -345,6 +347,8 @@ public class GridLayout implements LayoutManager {
                             break;
                         case FILL:
                             size = size.withRows(availableVerticalSpace);
+                            break;
+                        default:
                             break;
                     }
 

--- a/src/main/java/com/googlecode/lanterna/gui2/RadioBoxList.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/RadioBoxList.java
@@ -50,8 +50,8 @@ public class RadioBoxList<V> extends AbstractListBox<V, RadioBoxList<V>> {
     }
 
     @Override
-    protected ListItemRenderer createDefaultListItemRenderer() {
-        return new RadioBoxListItemRenderer();
+    protected ListItemRenderer<V,RadioBoxList<V>> createDefaultListItemRenderer() {
+        return new RadioBoxListItemRenderer<V>();
     }
 
     @Override
@@ -154,16 +154,16 @@ public class RadioBoxList<V> extends AbstractListBox<V, RadioBoxList<V>> {
         invalidate();
     }
 
-    public static class RadioBoxListItemRenderer extends ListItemRenderer {
+    public static class RadioBoxListItemRenderer<V> extends ListItemRenderer<V,RadioBoxList<V>> {
         @Override
         protected int getHotSpotPositionOnLine(int selectedIndex) {
             return 1;
         }
 
         @Override
-        protected String getLabel(AbstractListBox<?, ?> listBox, int index, Object item) {
+        protected String getLabel(RadioBoxList<V> listBox, int index, V item) {
             String check = " ";
-            if(((RadioBoxList)listBox).checkedIndex == index)
+            if(listBox.checkedIndex == index)
                 check = "o";
 
             String text = (item != null ? item : "<null>").toString();

--- a/src/main/java/com/googlecode/lanterna/screen/AbstractScreen.java
+++ b/src/main/java/com/googlecode/lanterna/screen/AbstractScreen.java
@@ -245,4 +245,9 @@ public abstract class AbstractScreen implements Screen {
         }
         return buffer.getCharacterAt(column, row);
     }
+    
+    @Override
+    public String toString() {
+        return getBackBuffer().toString();
+    }
 }

--- a/src/main/java/com/googlecode/lanterna/screen/ScreenBuffer.java
+++ b/src/main/java/com/googlecode/lanterna/screen/ScreenBuffer.java
@@ -129,4 +129,9 @@ public class ScreenBuffer implements TextImage {
     public void copyFrom(TextImage source, int startRowIndex, int rows, int startColumnIndex, int columns, int destinationRowOffset, int destinationColumnOffset) {
         source.copyTo(backend, startRowIndex, rows, startColumnIndex, columns, destinationRowOffset, destinationColumnOffset);
     }
+    
+    @Override
+    public String toString() {
+        return backend.toString();
+    }
 }

--- a/src/main/java/com/googlecode/lanterna/terminal/IOSafeExtendedTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/IOSafeExtendedTerminal.java
@@ -1,0 +1,40 @@
+package com.googlecode.lanterna.terminal;
+
+/**
+ * Interface extending ExtendedTerminal that removes the IOException throw clause.
+ * 
+ * @author Martin
+ * @author Andreas
+ */
+public interface IOSafeExtendedTerminal extends IOSafeTerminal,ExtendedTerminal {
+
+    @Override
+    void setTerminalSize(int columns, int rows);
+
+    @Override
+    void setTitle(String title);
+
+    @Override
+    void pushTitle();
+
+    @Override
+    void popTitle();
+
+    @Override
+    void iconify();
+
+    @Override
+    void deiconify();
+
+    @Override
+    void maximize();
+
+    @Override
+    void unmaximize();
+
+    @Override
+    void setMouseMovementCapturingEnabled(boolean enabled);
+
+    @Override
+    void setMouseClicksCapturingEnabled(boolean enable);
+}

--- a/src/main/java/com/googlecode/lanterna/terminal/IOSafeTerminalAdapter.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/IOSafeTerminalAdapter.java
@@ -56,7 +56,21 @@ public class IOSafeTerminalAdapter implements IOSafeTerminal {
      * @return IOSafeTerminal wrapping the supplied terminal
      */
     public static IOSafeTerminal createRuntimeExceptionConvertingAdapter(Terminal terminal) {
-        return new IOSafeTerminalAdapter(terminal, new ConvertToRuntimeException());
+        if (terminal instanceof ExtendedTerminal) { // also handle Runtime-type:
+            return createRuntimeExceptionConvertingAdapter((ExtendedTerminal)terminal);
+        } else {
+            return new IOSafeTerminalAdapter(terminal, new ConvertToRuntimeException());
+        }
+    }
+    
+    /**
+     * Creates a wrapper around an ExtendedTerminal that exposes it as a IOSafeExtendedTerminal.
+     * If any IOExceptions occur, they will be wrapped by a RuntimeException and re-thrown.
+     * @param terminal Terminal to wrap
+     * @return IOSafeTerminal wrapping the supplied terminal
+     */
+    public static IOSafeExtendedTerminal createRuntimeExceptionConvertingAdapter(ExtendedTerminal terminal) {
+        return new IOSafeTerminalAdapter.Extended(terminal, new ConvertToRuntimeException());
     }
     
     /**
@@ -66,11 +80,26 @@ public class IOSafeTerminalAdapter implements IOSafeTerminal {
      * @return IOSafeTerminal wrapping the supplied terminal
      */
     public static IOSafeTerminal createDoNothingOnExceptionAdapter(Terminal terminal) {
-        return new IOSafeTerminalAdapter(terminal, new DoNothingAndOrReturnNull());
+        if (terminal instanceof ExtendedTerminal) { // also handle Runtime-type:
+            return createDoNothingOnExceptionAdapter((ExtendedTerminal)terminal);
+        } else {
+            return new IOSafeTerminalAdapter(terminal, new DoNothingAndOrReturnNull());
+        }
     }
-        
+
+    /**
+     * Creates a wrapper around an ExtendedTerminal that exposes it as a IOSafeExtendedTerminal.
+     * If any IOExceptions occur, they will be silently ignored and for those method with a 
+     * non-void return type, null will be returned.
+     * @param terminal Terminal to wrap
+     * @return IOSafeTerminal wrapping the supplied terminal
+     */
+    public static IOSafeExtendedTerminal createDoNothingOnExceptionAdapter(ExtendedTerminal terminal) {
+        return new IOSafeTerminalAdapter.Extended(terminal, new DoNothingAndOrReturnNull());
+    }
+
     private final Terminal backend;
-    private final ExceptionHandler exceptionHandler;
+    final ExceptionHandler exceptionHandler;
 
     @SuppressWarnings("WeakerAccess")
     public IOSafeTerminalAdapter(Terminal backend, ExceptionHandler exceptionHandler) {
@@ -255,5 +284,118 @@ public class IOSafeTerminalAdapter implements IOSafeTerminal {
             exceptionHandler.onException(e);
         }
         return null;
+    }
+
+    /**
+     * This class exposes methods for converting an extended terminal into an IOSafeExtendedTerminal.
+     */
+    public static class Extended extends IOSafeTerminalAdapter implements IOSafeExtendedTerminal {
+        private final ExtendedTerminal backend;
+        
+        public Extended(ExtendedTerminal backend, ExceptionHandler exceptionHandler) {
+            super(backend, exceptionHandler);
+            this.backend = backend;
+        }
+
+        @Override
+        public void setTerminalSize(int columns, int rows) {
+            try {
+                backend.setTerminalSize(columns, rows);
+            }
+            catch(IOException e) {
+                exceptionHandler.onException(e);
+            }
+        }
+
+        @Override
+        public void setTitle(String title) {
+            try {
+                backend.setTitle(title);
+            }
+            catch(IOException e) {
+                exceptionHandler.onException(e);
+            }
+        }
+
+        @Override
+        public void pushTitle() {
+            try {
+                backend.pushTitle();
+            }
+            catch(IOException e) {
+                exceptionHandler.onException(e);
+            }
+        }
+
+        @Override
+        public void popTitle() {
+            try {
+                backend.popTitle();
+            }
+            catch(IOException e) {
+                exceptionHandler.onException(e);
+            }
+        }
+
+        @Override
+        public void iconify() {
+            try {
+                backend.iconify();
+            }
+            catch(IOException e) {
+                exceptionHandler.onException(e);
+            }
+        }
+
+        @Override
+        public void deiconify() {
+            try {
+                backend.deiconify();
+            }
+            catch(IOException e) {
+                exceptionHandler.onException(e);
+            }
+        }
+
+        @Override
+        public void maximize() {
+            try {
+                backend.maximize();
+            }
+            catch(IOException e) {
+                exceptionHandler.onException(e);
+            }
+        }
+
+        @Override
+        public void unmaximize() {
+            try {
+                backend.unmaximize();
+            }
+            catch(IOException e) {
+                exceptionHandler.onException(e);
+            }
+        }
+
+        @Override
+        public void setMouseMovementCapturingEnabled(boolean enable) {
+            try {
+                backend.setMouseMovementCapturingEnabled(enable);
+            }
+            catch(IOException e) {
+                exceptionHandler.onException(e);
+            }
+        }
+
+        @Override
+        public void setMouseClicksCapturingEnabled(boolean enable) {
+            try {
+                backend.setMouseClicksCapturingEnabled(enable);
+            }
+            catch(IOException e) {
+                exceptionHandler.onException(e);
+            }
+        }
+
     }
 }

--- a/src/main/java/com/googlecode/lanterna/terminal/ansi/TelnetTerminalServer.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/ansi/TelnetTerminalServer.java
@@ -21,7 +21,6 @@ package com.googlecode.lanterna.terminal.ansi;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.net.SocketException;
 import java.nio.charset.Charset;
 import javax.net.ServerSocketFactory;
 

--- a/src/test/java/com/googlecode/lanterna/gui2/ListBoxTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/ListBoxTest.java
@@ -21,8 +21,8 @@ public class ListBoxTest extends TestBase {
         horizontalPanel.setLayoutManager(new LinearLayout(Direction.HORIZONTAL));
 
         TerminalSize size = new TerminalSize(14, 10);
-        CheckBoxList checkBoxList = new CheckBoxList(size);
-        RadioBoxList radioBoxList = new RadioBoxList(size);
+        CheckBoxList<String> checkBoxList = new CheckBoxList<String>(size);
+        RadioBoxList<String> radioBoxList = new RadioBoxList<String>(size);
         ActionListBox actionListBox = new ActionListBox(size);
         for(int i = 0; i < 30; i++) {
             final String itemText = "Item " + (i + 1);


### PR DESCRIPTION
When debugging a TextGui program, it is most useful to be able to watch the Screen's backbuffer as it is drawn to, rather than only after a refresh.  This commit adds a toString() to BasicTextImage and ScreenBuffer, but also to AbstractScreen(which passes it on to its backbuffer).

So far these classes all had their default toString, which made examination of contents rather hard.

This toString() is still rather simple, as it ignores attributes, CJK and colours, but enough to still help.

The result is a bit odd for VirtualScreen, as its backbuffer contains some, but not all the visible stuff. I haven't yet found out, why that is so.