### PR TITLE
Let users be able to use LinearLayout.Alignment

### DIFF
--- a/src/main/java/com/googlecode/lanterna/gui2/LinearLayout.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/LinearLayout.java
@@ -27,7 +27,7 @@ import java.util.List;
  * Simple layout manager the puts all components on a single line
  */
 public class LinearLayout implements LayoutManager {
-    enum Alignment {
+    public enum Alignment {
         Beginning,
         Center,
         End,


### PR DESCRIPTION
I was trying to implement a toolbar similar to what nano does (see screenshot) and to do that wanted to use panels with horizontal linear layout filled on a panel. However I noticed that I'm unable to assign layout data to the action I was trying to put at the end of panel. This change fixes visibility of Alignment.

![image](https://cloud.githubusercontent.com/assets/820057/8711204/93fdda06-2b58-11e5-9fb3-c41135fe1f90.png)
