### PR TITLE
Fix of getTextGUI always returning null

### DIFF
--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractBasePane.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractBasePane.java
@@ -227,6 +227,11 @@ public abstract class AbstractBasePane implements BasePane {
         }
 
         @Override
+        public TextGUI getTextGUI() {
+            return AbstractBasePane.this.getTextGUI();
+        }
+
+        @Override
         protected ComponentRenderer<Container> createDefaultRenderer() {
             return new ComponentRenderer<Container>() {
                 @Override


### PR DESCRIPTION
In any Component I used getTextGUI was returning null.
This looks like because getTextGUI merely delegates to the parent,
but AbstractBasePane.ContentHolder parent always null, since
it is a root of hierarchy. This makes this root Component return
meaningful TextGUI instance.