### PR TITLE
fixes for issues #150 and #164

### DIFF
--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractBasePane.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractBasePane.java
@@ -58,8 +58,9 @@ public abstract class AbstractBasePane implements BasePane {
 
         if(!interactableLookupMap.getSize().equals(graphics.getSize())) {
             interactableLookupMap = new InteractableLookupMap(graphics.getSize());
+        } else {
+            interactableLookupMap.reset();
         }
-        interactableLookupMap.reset();
         contentHolder.updateLookupMap(interactableLookupMap);
         //interactableLookupMap.debug();
         invalid = false;

--- a/src/main/java/com/googlecode/lanterna/gui2/InteractableLookupMap.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/InteractableLookupMap.java
@@ -35,6 +35,9 @@ public class InteractableLookupMap {
     public InteractableLookupMap(TerminalSize size) {
         lookupMap = new int[size.getRows()][size.getColumns()];
         interactables = new ArrayList<Interactable>();
+        for (int[] aLookupMap : lookupMap) {
+            Arrays.fill(aLookupMap, -1);
+        }
     }
 
     public void reset() {

--- a/src/main/java/com/googlecode/lanterna/terminal/ansi/UnixLikeTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/ansi/UnixLikeTerminal.java
@@ -162,6 +162,14 @@ public abstract class UnixLikeTerminal extends ANSITerminal {
             @Override
             public void run() {
                 try {
+                    if (isInPrivateMode()) {
+                        exitPrivateMode();
+                    }
+                }
+                catch(IOException ignored) {}
+                catch(IllegalStateException ignored) {} // still possible!
+
+                try {
                     restoreSTTY();
                 }
                 catch(IOException ignored) {}


### PR DESCRIPTION
In case of Ctrl-C or System.exit() or uncaught exception, real terminals should be completely reset: not just the stty-stuff, but also exit the private mode (which restores the visible cursor,...)

This is in response to issue #150 .
