### PR TITLE
reworked scanning of input bytes into KeyStrokes. (+timeout, +test)

### DIFF
--- a/src/test/java/com/googlecode/lanterna/terminal/TerminalInputTest.java
+++ b/src/test/java/com/googlecode/lanterna/terminal/TerminalInputTest.java
@@ -20,6 +20,7 @@ package com.googlecode.lanterna.terminal;
 
 import com.googlecode.lanterna.input.KeyStroke;
 import com.googlecode.lanterna.input.KeyType;
+import com.googlecode.lanterna.terminal.ansi.StreamBasedTerminal;
 import com.googlecode.lanterna.TestTerminalFactory;
 import java.io.IOException;
 
@@ -35,13 +36,20 @@ public class TerminalInputTest {
 
         for(String arg: args) {
             if("--mouse-click".equals(arg)) {
-                ((ExtendedTerminal)rawTerminal).setMouseCaptureMode(MouseCaptureMode.CLICK_RELEASE);
+                if (rawTerminal instanceof ExtendedTerminal)
+                    ((ExtendedTerminal)rawTerminal).setMouseCaptureMode(MouseCaptureMode.CLICK_RELEASE);
             }
             else if("--mouse-drag".equals(arg)) {
-                ((ExtendedTerminal)rawTerminal).setMouseCaptureMode(MouseCaptureMode.CLICK_RELEASE_DRAG);
+                if (rawTerminal instanceof ExtendedTerminal)
+                    ((ExtendedTerminal)rawTerminal).setMouseCaptureMode(MouseCaptureMode.CLICK_RELEASE_DRAG);
             }
             else if("--mouse-move".equals(arg)) {
-                ((ExtendedTerminal)rawTerminal).setMouseCaptureMode(MouseCaptureMode.CLICK_RELEASE_DRAG_MOVE);
+                if (rawTerminal instanceof ExtendedTerminal)
+                    ((ExtendedTerminal)rawTerminal).setMouseCaptureMode(MouseCaptureMode.CLICK_RELEASE_DRAG_MOVE);
+            }
+            else if("--with-timeout".equals(arg)) {
+                if (rawTerminal instanceof StreamBasedTerminal)
+                    ((StreamBasedTerminal)rawTerminal).getInputDecoder().setTimeoutUnits(40); // 10s
             }
         }
 
@@ -70,7 +78,9 @@ public class TerminalInputTest {
             }
         }
 
-        ((ExtendedTerminal)rawTerminal).setMouseCaptureMode(null);
+        if (rawTerminal instanceof ExtendedTerminal)
+            ((ExtendedTerminal)rawTerminal).setMouseCaptureMode(null);
+
         rawTerminal.exitPrivateMode();
     }
 


### PR DESCRIPTION
+ merged my previous preview (8f2d09542015ca5eb26e154eccea2ad2e1d56a91) with all the latest changes on mabe02/lanterna
+ added configurable timeout (with default of 0)
+ added option to TerminalInputTest to allow testing (with rather long 10s timeout that allows to manually type escape sequences)
+ fixed ClassCastException in TerminalInputTest, when running with Swing (where mouse reporting and timeout settings don't apply yet)

I think this now solves issue #172 