### PR TITLE
Add shiftDown support to KeyStroke

### DIFF
--- a/src/main/java/com/googlecode/lanterna/input/DefaultKeyDecodingProfile.java
+++ b/src/main/java/com/googlecode/lanterna/input/DefaultKeyDecodingProfile.java
@@ -36,104 +36,17 @@ public class DefaultKeyDecodingProfile implements KeyDecodingProfile {
             = new ArrayList<CharacterPattern>(Arrays.asList(
                             new CharacterPattern[]{
                                 new BasicCharacterPattern(new KeyStroke(KeyType.Escape), ESC_CODE),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.ArrowUp), ESC_CODE, '[', 'A'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.ArrowUp, false, true), ESC_CODE, ESC_CODE, '[', 'A'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.ArrowUp, true, false), ESC_CODE, '[', '1', ';', '5', 'A'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.ArrowDown), ESC_CODE, '[', 'B'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.ArrowDown, false, true), ESC_CODE, ESC_CODE, '[', 'B'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.ArrowDown, true, false), ESC_CODE, '[', '1', ';', '5', 'B'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.ArrowRight), ESC_CODE, '[', 'C'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.ArrowRight, false, true), ESC_CODE, ESC_CODE, '[', 'C'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.ArrowRight, true, false), ESC_CODE, '[', '1', ';', '5', 'C'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.ArrowLeft), ESC_CODE, '[', 'D'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.ArrowLeft, false, true), ESC_CODE, ESC_CODE, '[', 'D'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.ArrowLeft, true, false), ESC_CODE, '[', '1', ';', '5', 'D'),
                                 new BasicCharacterPattern(new KeyStroke(KeyType.Tab), '\t'),
                                 new BasicCharacterPattern(new KeyStroke(KeyType.Enter), '\n'),
                                 new BasicCharacterPattern(new KeyStroke(KeyType.Enter), '\r', '\u0000'), //OS X
-                                new BasicCharacterPattern(new KeyStroke(KeyType.ReverseTab), ESC_CODE, '[', 'Z'),
                                 new BasicCharacterPattern(new KeyStroke(KeyType.Backspace), (char) 0x7f),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.Insert), ESC_CODE, '[', '2', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.Insert, false, true), ESC_CODE, ESC_CODE, '[', '2', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.Delete), ESC_CODE, '[', '3', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.Delete, false, true), ESC_CODE, ESC_CODE, '[', '3', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.Home), ESC_CODE, '[', 'H'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.Home, false, true), ESC_CODE, ESC_CODE, '[', 'H'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.Home), ESC_CODE, 'O', 'H'),  //Gnome terminal
-                                new BasicCharacterPattern(new KeyStroke(KeyType.Home), ESC_CODE, '[', '1', '~'), //Putty
-                                new BasicCharacterPattern(new KeyStroke(KeyType.End), ESC_CODE, '[', 'F'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.End, false, true), ESC_CODE, ESC_CODE, '[', 'F'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.End), ESC_CODE, 'O', 'F'),   //Gnome terminal
-                                new BasicCharacterPattern(new KeyStroke(KeyType.End), ESC_CODE, '[', '4', '~'),  //Putty
-                                new BasicCharacterPattern(new KeyStroke(KeyType.PageUp), ESC_CODE, '[', '5', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.PageUp, false, true), ESC_CODE, ESC_CODE, '[', '5', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.PageDown), ESC_CODE, '[', '6', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.PageDown, false, true), ESC_CODE, ESC_CODE, '[', '6', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F1), ESC_CODE, '[', '1', '1', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F1), ESC_CODE, 'O', 'P'), //Cygwin
                                 new BasicCharacterPattern(new KeyStroke(KeyType.F1), ESC_CODE, '[', '[', 'A'), //Linux
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F2), ESC_CODE, '[', '1', '2', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F2), ESC_CODE, 'O', 'Q'), //Cygwin
                                 new BasicCharacterPattern(new KeyStroke(KeyType.F2), ESC_CODE, '[', '[', 'B'), //Linux
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F3), ESC_CODE, '[', '1', '3', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F3), ESC_CODE, 'O', 'R'), //Cygwin
                                 new BasicCharacterPattern(new KeyStroke(KeyType.F3), ESC_CODE, '[', '[', 'C'), //Linux
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F4), ESC_CODE, '[', '1', '4', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F4), ESC_CODE, 'O', 'S'), //Cygwin
                                 new BasicCharacterPattern(new KeyStroke(KeyType.F4), ESC_CODE, '[', '[', 'D'), //Linux
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F5), ESC_CODE, '[', '1', '5', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F5), ESC_CODE, '[', '1', '6', '~'), 
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F5), ESC_CODE, '[', '3', '2', '~'), //Psion TekLogix
                                 new BasicCharacterPattern(new KeyStroke(KeyType.F5), ESC_CODE, '[', '[', 'E'), //Linux
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F6), ESC_CODE, '[', '1', '7', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F7), ESC_CODE, '[', '1', '8', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F8), ESC_CODE, '[', '1', '9', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F9), ESC_CODE, '[', '2', '0', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F10), ESC_CODE, '[', '2', '1', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F11), ESC_CODE, '[', '2', '3', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F12), ESC_CODE, '[', '2', '4', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F13), ESC_CODE, '[', '2', '5', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F14), ESC_CODE, '[', '2', '6', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F15), ESC_CODE, '[', '2', '8', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F16), ESC_CODE, '[', '2', '9', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F17), ESC_CODE, '[', '3', '1', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F18), ESC_CODE, '[', '3', '2', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F19), ESC_CODE, '[', '3', '3', '~'),
 
-                                //Function keys with alt
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F1, false, true), ESC_CODE, ESC_CODE, '[', '1', '1', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F1, false, true), ESC_CODE, ESC_CODE, 'O', 'P'), //Cygwin
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F2, false, true), ESC_CODE, ESC_CODE, '[', '1', '2', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F2, false, true), ESC_CODE, ESC_CODE, 'O', 'Q'), //Cygwin
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F3, false, true), ESC_CODE, ESC_CODE, '[', '1', '3', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F3, false, true), ESC_CODE, ESC_CODE, 'O', 'R'), //Cygwin
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F4, false, true), ESC_CODE, ESC_CODE, '[', '1', '4', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F4, false, true), ESC_CODE, ESC_CODE, 'O', 'S'), //Cygwin
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F5, false, true), ESC_CODE, ESC_CODE, '[', '1', '5', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F5, false, true), ESC_CODE, ESC_CODE, '[', '1', '6', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F5, false, true), ESC_CODE, ESC_CODE, '[', '3', '2', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F6, false, true), ESC_CODE, ESC_CODE, '[', '1', '7', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F7, false, true), ESC_CODE, ESC_CODE, '[', '1', '8', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F8, false, true), ESC_CODE, ESC_CODE, '[', '1', '9', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F9, false, true), ESC_CODE, ESC_CODE, '[', '2', '0', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F10, false, true), ESC_CODE, ESC_CODE, '[', '2', '1', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F11, false, true), ESC_CODE, ESC_CODE, '[', '2', '3', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F12, false, true), ESC_CODE, ESC_CODE, '[', '2', '4', '~'),
-
-                                //Function keys with ctrl
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F1, true, false), ESC_CODE, '[', '1', ';', '5', 'P'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F2, true, false), ESC_CODE, '[', '1', ';', '5', 'Q'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F3, true, false), ESC_CODE, '[', '1', ';', '5', 'R'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F4, true, false), ESC_CODE, '[', '1', ';', '5', 'S'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F5, true, false), ESC_CODE, '[', '1', '5', ';', '5', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F6, true, false), ESC_CODE, '[', '1', '7', ';', '5', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F7, true, false), ESC_CODE, '[', '1', '8', ';', '5', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F8, true, false), ESC_CODE, '[', '1', '9', ';', '5', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F9, true, false), ESC_CODE, '[', '2', '0', ';', '5', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F10, true, false), ESC_CODE, '[', '2', '1', ';', '5', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F11, true, false), ESC_CODE, '[', '2', '3', ';', '5', '~'),
-                                new BasicCharacterPattern(new KeyStroke(KeyType.F12, true, false), ESC_CODE, '[', '2', '4', ';', '5', '~'),
-
+                                new EscapeSequenceCharacterPattern(),
                                 new NormalCharacterPattern(),
                                 new AltAndCharacterPattern(),
                                 new CtrlAndCharacterPattern(),

--- a/src/main/java/com/googlecode/lanterna/input/EscapeSequenceCharacterPattern.java
+++ b/src/main/java/com/googlecode/lanterna/input/EscapeSequenceCharacterPattern.java
@@ -1,0 +1,189 @@
+package com.googlecode.lanterna.input;
+
+import static com.googlecode.lanterna.input.KeyDecodingProfile.ESC_CODE;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This implementation of CharacterPattern matches two similar patterns
+ * of Escape sequences, that many terminals produce for special keys.<p>
+ * 
+ * These sequences start with Escape, followed by either an open bracket
+ * or a capital letter O (these two are treated as equivalent).<p>
+ * 
+ * Then follows a list of zero or up to two decimals separated by a 
+ * semicolon, and a non-digit last character.<p>
+ * 
+ * If the last character is a tilde (~) then the first number defines
+ * the key (through stdMap), otherwise the last character itself defines
+ * the key (through finMap).<p>
+ * 
+ * The second number, if provided by the terminal, specifies the modifier
+ * state (shift,alt,ctrl). The value is 1 + sum(modifiers), where shift is 1,
+ * alt is 2 and ctrl is 4.<p>
+ * 
+ * The two maps stdMap and finMap can be customized in subclasses to add,
+ * remove or replace keys - to support non-standard Terminals.<p>
+ * 
+ * Examples: (on a gnome terminal)<br>
+ * ArrowUp is "Esc [ A"; Alt-ArrowUp is "Esc [ 1 ; 3 A"<br>
+ * both are handled by finMap mapping 'A' to ArrowUp <br><br>
+ * F6 is "Esc [ 1 7 ~"; Ctrl-Shift-F6 is "Esc [ 1 7 ; 6 R"<br>
+ * both are handled by stdMap mapping 17 to F6 <br><br>
+ * 
+ * @author Andreas L.
+ *
+ */
+public class EscapeSequenceCharacterPattern implements CharacterPattern {
+    // state machine used to match key sequence:
+    private enum State {
+        START, INTRO, NUM1, NUM2, DONE;
+    }
+    // bit-values for modifier keys: only used internally
+    private static final int SHIFT = 1, ALT = 2, CTRL = 4;
+
+    // Retain information from successful call to matches():
+    // overridden methods can access them for customization.
+    protected List<Character> cacheSeq = null;
+    protected KeyType cacheKey; protected int cacheMods;
+
+    /**
+     *  Map of recognized "standard pattern" sequences:<br>
+     *   e.g.: 24 -> F12 : "Esc [ <b>24</b> ~"
+     */
+    protected final Map<Integer, KeyType>   stdMap = new HashMap<Integer, KeyType>();
+    /**
+     *  Map of recognized "finish pattern" sequences:<br>
+     *   e.g.: 'A' -> ArrowUp : "Esc [ <b>A</b>"
+     */
+    protected final Map<Character, KeyType> finMap = new HashMap<Character, KeyType>();
+
+    
+    /**
+     * Create an instance with a standard set of mappings.
+     */
+    public EscapeSequenceCharacterPattern() {
+        finMap.put('A', KeyType.ArrowUp);
+        finMap.put('B', KeyType.ArrowDown);
+        finMap.put('C', KeyType.ArrowRight);
+        finMap.put('D', KeyType.ArrowLeft);
+        finMap.put('H', KeyType.Home);
+        finMap.put('F', KeyType.End);
+        finMap.put('P', KeyType.F1);
+        finMap.put('Q', KeyType.F2);
+        finMap.put('R', KeyType.F3);
+        finMap.put('S', KeyType.F4);
+        finMap.put('Z', KeyType.ReverseTab);
+
+        stdMap.put(1,  KeyType.Home);
+        stdMap.put(2,  KeyType.Insert);
+        stdMap.put(3,  KeyType.Delete);
+        stdMap.put(4,  KeyType.End);
+        stdMap.put(5,  KeyType.PageUp);
+        stdMap.put(6,  KeyType.PageDown);
+        stdMap.put(11, KeyType.F1);
+        stdMap.put(12, KeyType.F2);
+        stdMap.put(13, KeyType.F3);
+        stdMap.put(14, KeyType.F4);
+        stdMap.put(15, KeyType.F5);
+        stdMap.put(16, KeyType.F5);
+        stdMap.put(17, KeyType.F6);
+        stdMap.put(18, KeyType.F7);
+        stdMap.put(19, KeyType.F8);
+        stdMap.put(20, KeyType.F9);
+        stdMap.put(21, KeyType.F10);
+        stdMap.put(23, KeyType.F11);
+        stdMap.put(24, KeyType.F12);
+        stdMap.put(25, KeyType.F13);
+        stdMap.put(26, KeyType.F14);
+        stdMap.put(28, KeyType.F15);
+        stdMap.put(29, KeyType.F16);
+        stdMap.put(31, KeyType.F17);
+        stdMap.put(32, KeyType.F18);
+        stdMap.put(33, KeyType.F19);
+    }
+
+    @Override
+    public KeyStroke getResult(List<Character> cur) {
+        if (cacheSeq != cur) {
+            return null;
+        }
+        boolean bShift = false, bCtrl = false, bAlt = false;
+        if (cacheMods > 0) {
+            int mods = cacheMods - 1;
+            bShift = (mods & SHIFT) != 0;
+            bAlt   = (mods & ALT)   != 0;
+            bCtrl  = (mods & CTRL)  != 0;
+        }
+        return new KeyStroke( cacheKey , bCtrl, bAlt, bShift);
+    }
+
+    @Override
+    public boolean isCompleteMatch(List<Character> cur) {
+        return cacheSeq == cur; // assume that matches() was checked before
+    }
+
+    @Override
+    public boolean matches(List<Character> cur) {
+        State state = State.START; cacheSeq = null;
+        int num1 = 0, num2 = 0; char last = '\0';
+
+        for (char ch : cur) {
+            switch (state) {
+            case START:
+                if (ch != ESC_CODE) {
+                    return false;
+                }
+                state = State.INTRO;
+                continue;
+            case INTRO:
+                // Accept a second Escape to mean "Alt is pressed"?
+                // according to local terminfo database, no terminal
+                // seems to send it that way, but just in case...
+                //if (ch == ESC_CODE && num2 == 0) {
+                //    num2 = 1 + ALT; continue;
+                //}
+
+                // Key sequences supported by this class must
+                //    start either with Esc-[ or Esc-O
+                if (ch != '[' && ch != 'O') {
+                    return false;
+                }
+                state = State.NUM1;
+                continue;
+            case NUM1:
+                if (ch == ';') {
+                    state = State.NUM2;
+                } else if (Character.isDigit(ch)) {
+                    num1 = num1 * 10 + Character.digit(ch, 10);
+                } else {
+                    last = ch; state = State.DONE;
+                }
+                continue;
+            case NUM2:
+                if (Character.isDigit(ch)) {
+                    num2 = num2 * 10 + Character.digit(ch, 10);
+                } else {
+                    last = ch; state = State.DONE;
+                }
+                continue;
+            case DONE: // once done, extra characters spoil it
+                return false;
+            }
+        }
+        if (state == State.DONE) {
+            if (last == '~' && stdMap.containsKey(num1)) {
+                cacheSeq = cur; cacheMods = num2;
+                cacheKey = stdMap.get(num1);
+            } else if (finMap.containsKey(last)) {
+                cacheSeq = cur; cacheMods = num2;
+                cacheKey = finMap.get(last);
+            } else {
+                return false; // unknown key.
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/googlecode/lanterna/input/KeyStroke.java
+++ b/src/main/java/com/googlecode/lanterna/input/KeyStroke.java
@@ -40,6 +40,7 @@ public class KeyStroke {
     private final Character character;
     private final boolean ctrlDown;
     private final boolean altDown;
+    private final boolean shiftDown;
     private final long eventTime;
 
     /**
@@ -61,20 +62,36 @@ public class KeyStroke {
      * @param altDown Was alt held down when the main key was pressed?
      */
     public KeyStroke(KeyType keyType, boolean ctrlDown, boolean altDown) {
-        this(keyType, null, ctrlDown, altDown);
+        this(keyType, null, ctrlDown, altDown, false);
+    }
+    
+    /**
+     * Constructs a KeyStroke based on a supplied keyType; character will be null.
+     * If you try to construct a KeyStroke with type KeyType.Character with this constructor, it
+     * will always throw an exception; use another overload that allows you to specify the character value instead.
+     * @param keyType Type of the key pressed by this keystroke
+     * @param ctrlDown Was ctrl held down when the main key was pressed?
+     * @param altDown Was alt held down when the main key was pressed?
+     * @param shiftDown Was shift held down when the main key was pressed?
+     */
+    public KeyStroke(KeyType keyType, boolean ctrlDown, boolean altDown, boolean shiftDown) {
+        this(keyType, null, ctrlDown, altDown, shiftDown);
     }
     
     /**
      * Constructs a KeyStroke based on a supplied character, keyType is implicitly KeyType.Character.
+     * <p>
+     * A character-based KeyStroke does not support the shiftDown flag, as the shift state has
+     * already been accounted for in the character itself, depending on user's keyboard layout.
      * @param character Character that was typed on the keyboard
      * @param ctrlDown Was ctrl held down when the main key was pressed?
      * @param altDown Was alt held down when the main key was pressed?
      */
     public KeyStroke(Character character, boolean ctrlDown, boolean altDown) {
-        this(KeyType.Character, character, ctrlDown, altDown);
+        this(KeyType.Character, character, ctrlDown, altDown, false);
     }
     
-    private KeyStroke(KeyType keyType, Character character, boolean ctrlDown, boolean altDown) {
+    private KeyStroke(KeyType keyType, Character character, boolean ctrlDown, boolean altDown, boolean shiftDown) {
         if(keyType == KeyType.Character && character == null) {
             throw new IllegalArgumentException("Cannot construct a KeyStroke with type KeyType.Character but no character information");
         }
@@ -93,6 +110,7 @@ public class KeyStroke {
         }
         this.keyType = keyType;
         this.character = character;
+        this.shiftDown = shiftDown;
         this.ctrlDown = ctrlDown;
         this.altDown = altDown;
         this.eventTime = System.currentTimeMillis();
@@ -132,6 +150,13 @@ public class KeyStroke {
     }
 
     /**
+     * @return Returns true if shift was help down while the key was typed (depending on terminal implementation)
+     */
+    public boolean isShiftDown() {
+        return shiftDown;
+    }
+
+    /**
      * Gets the time when the keystroke was recorded. This isn't necessarily the time the keystroke happened, but when
      * Lanterna received the event, so it may not be accurate down to the millisecond.
      * @return The unix time of when the keystroke happened, in milliseconds
@@ -142,7 +167,10 @@ public class KeyStroke {
 
     @Override
     public String toString() {
-        return "KeyStroke{" + "keyType=" + keyType + ", character=" + character + ", ctrlDown=" + ctrlDown + ", altDown=" + altDown + '}';
+        return "KeyStroke{" + "keyType=" + keyType + ", character=" + character + 
+                ", ctrlDown=" + ctrlDown + 
+                ", altDown=" + altDown + 
+                ", shiftDown=" + shiftDown + '}';
     }
 
     @Override
@@ -152,6 +180,7 @@ public class KeyStroke {
         hash = 41 * hash + (this.character != null ? this.character.hashCode() : 0);
         hash = 41 * hash + (this.ctrlDown ? 1 : 0);
         hash = 41 * hash + (this.altDown ? 1 : 0);
+        hash = 41 * hash + (this.shiftDown ? 1 : 0);
         return hash;
     }
 
@@ -171,7 +200,9 @@ public class KeyStroke {
         if (this.character != other.character && (this.character == null || !this.character.equals(other.character))) {
             return false;
         }
-        return this.ctrlDown == other.ctrlDown && this.altDown == other.altDown;
+        return this.ctrlDown == other.ctrlDown && 
+               this.altDown == other.altDown &&
+               this.shiftDown == other.shiftDown;
     }
     
     /**
@@ -184,7 +215,7 @@ public class KeyStroke {
         String keyStrLC = keyStr.toLowerCase();
         KeyStroke k;
         if (keyStr.length() == 1) {
-            k = new KeyStroke(KeyType.Character, keyStr.charAt(0), false, false);
+            k = new KeyStroke(KeyType.Character, keyStr.charAt(0), false, false, false);
         } else if (keyStr.startsWith("<") && keyStr.endsWith(">")) {
             if (keyStrLC.equals("<s-tab>")) {
                 k = new KeyStroke(KeyType.ReverseTab);


### PR DESCRIPTION
This is a first step towards supporting shifted cursor keys, function keys, home,end,pgup,pgdn.

Shift-flag is specifically **not** supported for character KeyStrokes. E.g.: "Shift-6" is '^' for English keyboards and '&' for German ones. Shift-Tab is still possible, but should be mapped to ReverseTab.

Next step will be a new CharacterPattern implementing class, that will replace  most of the individual BasicCharacterPatterns in the DefaultKeyDecodingProfile, and will support any combination of alt,ctrl,shift for some special keys, while avoiding to specify all 8 variants for each of them.