### PR TITLE
CharacterPattern change

### DIFF
--- a/src/main/java/com/googlecode/lanterna/input/AltAndCharacterPattern.java
+++ b/src/main/java/com/googlecode/lanterna/input/AltAndCharacterPattern.java
@@ -22,23 +22,24 @@ import java.util.List;
 
 /**
  * Character pattern that matches characters pressed while ALT key is held down
+ * 
+ * @author Martin, Andreas
  */
 public class AltAndCharacterPattern implements CharacterPattern {
-    @Override
-    public KeyStroke getResult(List<Character> matching) {
-        return new KeyStroke(matching.get(1), false, true);
-    }
 
     @Override
-    public boolean isCompleteMatch(List<Character> currentMatching) {
-        return currentMatching.size() == 2 &&
-                currentMatching.get(0) == KeyDecodingProfile.ESC_CODE &&
-                Character.isLetterOrDigit(currentMatching.get(1));
-    }
-
-    @Override
-    public boolean matches(List<Character> currentMatching) {
-        return currentMatching.get(0) == KeyDecodingProfile.ESC_CODE &&
-                (currentMatching.size() == 1 || (Character.isLetterOrDigit(currentMatching.get(1)) && currentMatching.size() == 2));
+    public Matching match(List<Character> seq) {
+        int size = seq.size();
+        if (size > 2 || seq.get(0) != KeyDecodingProfile.ESC_CODE) {
+            return null; // nope
+        }
+        if (size == 1) {
+            return Matching.NOT_YET; // maybe later
+        }
+        if ( Character.isISOControl(seq.get(1)) ) {
+            return null; // nope
+        }
+        KeyStroke ks = new KeyStroke(seq.get(1), false, true);
+        return new Matching( ks ); // yep
     }
 }

--- a/src/main/java/com/googlecode/lanterna/input/BasicCharacterPattern.java
+++ b/src/main/java/com/googlecode/lanterna/input/BasicCharacterPattern.java
@@ -24,6 +24,8 @@ import java.util.List;
 /**
  * Very simple pattern that matches the input stream against a pre-defined list of characters. For the pattern to match,
  * the list of characters must match exactly what's coming in on the input stream.
+ * 
+ * @author Martin, Andreas
  */
 public class BasicCharacterPattern implements CharacterPattern {
     private final KeyStroke result;
@@ -51,27 +53,22 @@ public class BasicCharacterPattern implements CharacterPattern {
     }
 
     @Override
-    public boolean matches(List<Character> currentMatching) {
-        if(currentMatching.size() > pattern.length) {
-            return false;
+    public Matching match(List<Character> seq) {
+        int size = seq.size();
+        
+        if(size > pattern.length) {
+            return null; // nope
         }
-        int minSize = Math.min(currentMatching.size(), pattern.length);
-        for (int i = 0; i < minSize; i++) {
-            if (pattern[i] != currentMatching.get(i)) {
-                return false;
+        for (int i = 0; i < size; i++) {
+            if (pattern[i] != seq.get(i)) {
+                return null; // nope
             }
         }
-        return true;
-    }
-
-    @Override
-    public KeyStroke getResult(List<Character> matching) {
-        return result;
-    }
-
-    @Override
-    public boolean isCompleteMatch(List<Character> currentMatching) {
-        return pattern.length == currentMatching.size();
+        if (size == pattern.length) {
+            return new Matching( getResult() ); // yep
+        } else {
+            return Matching.NOT_YET; // maybe later
+        }
     }
 
     @Override
@@ -81,7 +78,7 @@ public class BasicCharacterPattern implements CharacterPattern {
         }
 
         BasicCharacterPattern other = (BasicCharacterPattern) obj;
-        return Arrays.equals(pattern, other.pattern);
+        return Arrays.equals(this.pattern, other.pattern);
     }
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/input/CharacterPattern.java
+++ b/src/main/java/com/googlecode/lanterna/input/CharacterPattern.java
@@ -24,31 +24,72 @@ import java.util.List;
  * Used to compare a list of character if they match a particular pattern, and in that case, return the kind of 
  * keystroke this pattern represents
  *
- * @author martin
+ * @author Martin, Andreas
  */
 @SuppressWarnings("WeakerAccess")
 public interface CharacterPattern {
 
     /**
-     * Given a list of characters that this pattern is matching, which keystroke does it map to?
-     * @param matching List of characters
-     * @return The {@code Key} that this pattern represents
+     * Given a list of characters, determine whether it exactly matches
+     * any known KeyStroke, and whether a longer sequence can possibly match.
+     * @param List of characters to check
+     * @return see {@code Matching}
      */
-    KeyStroke getResult(List<Character> matching);
+    Matching match(List<Character> seq);
 
     /**
-     * Returns true if this pattern is a perfect match (all characters matching and the pattern has no more characters
-     * to match) of the supplied characters
-     * @param currentMatching List of characters
-     * @return True if the list of characters makes a complete (non-partial) match of this pattern
+     * This immutable class describes a matching result. It wraps two items,
+     * partialMatch and fullMatch.<dl>
+     * <dt>fullMatch</dt><dd>
+     *   The resulting KeyStroke if the pattern matched, otherwise null.<br>
+     *     Example: if the tested sequence is {@code Esc [ A}, and if the
+     *      pattern recognized this as {@code ArrowUp}, then this field has
+     *      a value like {@code new KeyStroke(KeyType.ArrowUp)}</dd>
+     * <dt>partialMatch</dt><dd>
+     *   {@code true}, if appending appropriate characters at the end of the 
+     *      sequence <i>can</i> produce a match.<br>
+     *     Example: if the tested sequence is "Esc [", and the Pattern would match
+     *      "Esc [ A", then this field would be set to {@code true}.</dd>
+     * <p> 
+     * In principle, a sequence can match one KeyStroke, but also say that if 
+     * another character is available, then a different KeyStroke might result.
+     * This can happen, if (e.g.) a single CharacterPattern-instance matches
+     * both the Escape key and a longer Escape-sequence.
      */
-    boolean isCompleteMatch(List<Character> currentMatching);
+    static class Matching {
+        public final KeyStroke fullMatch;
+        public final boolean partialMatch;
+        
+        /**
+         * Re-usable result for "not yet" half-matches
+         */
+        public static final Matching NOT_YET = new Matching( true, null );
 
-    /**
-     * Returns true if this pattern partially or fully matches the supplied characters
-     * @param currentMatching List of characters
-     * @return True if this pattern matches fully or partially the supplied list of characters
-     */
-    boolean matches(List<Character> currentMatching);
+        /**
+         * Convenience constructor for exact matches
+         * 
+         * @param fullMatch  the KeyStroke that matched the sequence
+         */
+        public Matching(KeyStroke fullMatch) {
+            this(false,fullMatch);
+        }
+        /**
+         * General constructor<p>
+         * For mismatches rather use {@code null} and for "not yet" matches use NOT_YET.
+         * Use this constructor, where a sequence may yield both fullMatch and
+         * partialMatch or for merging result Matchings of multiple patterns.
+         * 
+         * @param partialMatch  true if further characters could lead to a match
+         * @param fullMatch     The perfectly matching KeyStroke
+         */
+        public Matching(boolean partialMatch, KeyStroke fullMatch) {
+            this.partialMatch = partialMatch;
+            this.fullMatch = fullMatch;
+        }
 
+        @Override
+        public String toString() {
+            return "Matching{" + "partialMatch=" + partialMatch + ", fullMatch=" + fullMatch + '}';
+        }
+    }
 }

--- a/src/main/java/com/googlecode/lanterna/input/CtrlAltAndCharacterPattern.java
+++ b/src/main/java/com/googlecode/lanterna/input/CtrlAltAndCharacterPattern.java
@@ -22,26 +22,36 @@ import java.util.List;
 
 /**
  * Character pattern that matches characters pressed while ALT and CTRL keys are held down
- * @author Martin
+ * 
+ * @author Martin, Andreas
  */
 public class CtrlAltAndCharacterPattern implements CharacterPattern {
 
     @Override
-    public KeyStroke getResult(List<Character> matching) {
-        int firstCode = 'a' - 1;
-        return new KeyStroke((char) (firstCode + (int) matching.get(1)), true, true);
-    }
-
-    @Override
-    public boolean isCompleteMatch(List<Character> currentMatching) {
-        return currentMatching.size() == 2 &&
-                currentMatching.get(0) == KeyDecodingProfile.ESC_CODE &&
-                currentMatching.get(1) <= 26;
-    }
-
-    @Override
-    public boolean matches(List<Character> currentMatching) {
-        return currentMatching.get(0) == KeyDecodingProfile.ESC_CODE &&
-                (currentMatching.size() == 1 || (currentMatching.get(1) <= 26 && currentMatching.size() == 2));
+    public Matching match(List<Character> seq) {
+        int size = seq.size();
+        if (size > 2 || seq.get(0) != KeyDecodingProfile.ESC_CODE) {
+            return null; // nope
+        }
+        if (size == 1) {
+            return Matching.NOT_YET; // maybe later
+        }
+        char ch = seq.get(1);
+        if (ch < 32) {
+            // Control-chars: exclude Esc(^[), but still include ^\, ^], ^^ and ^_
+            char ctrlCode;
+            switch (ch) {
+            case KeyDecodingProfile.ESC_CODE: return null; // nope
+            case 28: /* ^\ */ ctrlCode = '\\'; break;
+            case 29: /* ^] */ ctrlCode = ']'; break;
+            case 30: /* ^^ */ ctrlCode = '^'; break;
+            case 31: /* ^_ */ ctrlCode = '_'; break;
+            default: ctrlCode = (char)('a' - 1 + ch);
+            }
+            KeyStroke ks = new KeyStroke( ctrlCode, true, true);
+            return new Matching( ks ); // yep
+        } else {
+            return null; // nope
+        }
     }
 }

--- a/src/main/java/com/googlecode/lanterna/input/CtrlAltAndCharacterPattern.java
+++ b/src/main/java/com/googlecode/lanterna/input/CtrlAltAndCharacterPattern.java
@@ -42,6 +42,7 @@ public class CtrlAltAndCharacterPattern implements CharacterPattern {
             char ctrlCode;
             switch (ch) {
             case KeyDecodingProfile.ESC_CODE: return null; // nope
+            case 0:  /* ^@ */ ctrlCode = ' '; break;
             case 28: /* ^\ */ ctrlCode = '\\'; break;
             case 29: /* ^] */ ctrlCode = ']'; break;
             case 30: /* ^^ */ ctrlCode = '^'; break;

--- a/src/main/java/com/googlecode/lanterna/input/CtrlAndCharacterPattern.java
+++ b/src/main/java/com/googlecode/lanterna/input/CtrlAndCharacterPattern.java
@@ -22,27 +22,32 @@ import java.util.List;
 
 /**
  * Character pattern that matches characters pressed while CTRL key is held down
- * @author Martin
+ * 
+ * @author Martin, Andreas
  */
 public class CtrlAndCharacterPattern implements CharacterPattern {
     @Override
-    public KeyStroke getResult(List<Character> matching) {
-        int firstCode = 'a' - 1;
-        return new KeyStroke((char) (firstCode + (int) matching.get(0)), true, false);
-    }
-
-    @Override
-    public boolean isCompleteMatch(List<Character> currentMatching) {
-        return matches(currentMatching);
-    }
-
-    @Override
-    public boolean matches(List<Character> currentMatching) {
-        return currentMatching.size() <= 1 &&
-                !(currentMatching.get(0) == '\n' ||
-                        currentMatching.get(0) == '\r' ||
-                        currentMatching.get(0) == '\t') &&
-                currentMatching.get(0) <= 26;
-
+    public Matching match(List<Character> seq) {
+        int size = seq.size(); char ch = seq.get(0);
+        if (size != 1) {
+            return null; // nope
+        }
+        if (ch < 32) {
+            // Control-chars: exclude lf,cr,Tab,Esc(^[), but still include ^\, ^], ^^ and ^_
+            char ctrlCode;
+            switch (ch) {
+            case '\n': case '\r': case '\t':
+            case KeyDecodingProfile.ESC_CODE: return null; // nope
+            case 28: /* ^\ */ ctrlCode = '\\'; break;
+            case 29: /* ^] */ ctrlCode = ']'; break;
+            case 30: /* ^^ */ ctrlCode = '^'; break;
+            case 31: /* ^_ */ ctrlCode = '_'; break;
+            default: ctrlCode = (char)('a' - 1 + ch);
+            }
+            KeyStroke ks = new KeyStroke( ctrlCode, true, true);
+            return new Matching( ks ); // yep
+        } else {
+            return null; // nope
+        }
     }
 }

--- a/src/main/java/com/googlecode/lanterna/input/CtrlAndCharacterPattern.java
+++ b/src/main/java/com/googlecode/lanterna/input/CtrlAndCharacterPattern.java
@@ -38,13 +38,14 @@ public class CtrlAndCharacterPattern implements CharacterPattern {
             switch (ch) {
             case '\n': case '\r': case '\t':
             case KeyDecodingProfile.ESC_CODE: return null; // nope
+            case 0:  /* ^@ */ ctrlCode = ' '; break;
             case 28: /* ^\ */ ctrlCode = '\\'; break;
             case 29: /* ^] */ ctrlCode = ']'; break;
             case 30: /* ^^ */ ctrlCode = '^'; break;
             case 31: /* ^_ */ ctrlCode = '_'; break;
             default: ctrlCode = (char)('a' - 1 + ch);
             }
-            KeyStroke ks = new KeyStroke( ctrlCode, true, true);
+            KeyStroke ks = new KeyStroke( ctrlCode, true, false);
             return new Matching( ks ); // yep
         } else {
             return null; // nope

--- a/src/main/java/com/googlecode/lanterna/input/EscapeSequenceCharacterPattern.java
+++ b/src/main/java/com/googlecode/lanterna/input/EscapeSequenceCharacterPattern.java
@@ -71,6 +71,8 @@ public class EscapeSequenceCharacterPattern implements CharacterPattern {
         finMap.put('B', KeyType.ArrowDown);
         finMap.put('C', KeyType.ArrowRight);
         finMap.put('D', KeyType.ArrowLeft);
+        finMap.put('E', KeyType.Unknown); // gnome-terminal center key on numpad
+        finMap.put('G', KeyType.Unknown); // putty center key on numpad
         finMap.put('H', KeyType.Home);
         finMap.put('F', KeyType.End);
         finMap.put('P', KeyType.F1);

--- a/src/main/java/com/googlecode/lanterna/input/NormalCharacterPattern.java
+++ b/src/main/java/com/googlecode/lanterna/input/NormalCharacterPattern.java
@@ -22,21 +22,22 @@ import java.util.List;
 
 /**
  * Character pattern that matches one character as one KeyStroke with the character that was read
+ * 
+ * @author Martin, Andreas
  */
 public class NormalCharacterPattern implements CharacterPattern {
     @Override
-    public KeyStroke getResult(List<Character> matching) {
-        return new KeyStroke(matching.get(0), false, false);
-    }
-
-    @Override
-    public boolean isCompleteMatch(List<Character> currentMatching) {
-        return currentMatching.size() == 1;
-    }
-
-    @Override
-    public boolean matches(List<Character> currentMatching) {
-        return currentMatching.size() == 1 && isPrintableChar(currentMatching.get(0));
+    public Matching match(List<Character> seq) {
+        if (seq.size() != 1) {
+            return null; // nope
+        }
+        char ch = seq.get(0);
+        if (isPrintableChar(ch)) {
+            KeyStroke ks = new KeyStroke(ch, false, false);
+            return new Matching( ks );
+        } else {
+            return null; // nope
+        }
     }
 
     /**
@@ -45,9 +46,8 @@ public class NormalCharacterPattern implements CharacterPattern {
      * @return True if this is a 'normal', printable character, false otherwise
      */
     private static boolean isPrintableChar(char c) {
+        if (Character.isISOControl(c)) { return false; }
         Character.UnicodeBlock block = Character.UnicodeBlock.of(c);
-        return (!Character.isISOControl(c)) &&
-                block != null &&
-                block != Character.UnicodeBlock.SPECIALS;
+        return block != null && block != Character.UnicodeBlock.SPECIALS;
     }
 }

--- a/src/main/java/com/googlecode/lanterna/input/ScreenInfoAction.java
+++ b/src/main/java/com/googlecode/lanterna/input/ScreenInfoAction.java
@@ -1,0 +1,32 @@
+package com.googlecode.lanterna.input;
+
+import com.googlecode.lanterna.TerminalPosition;
+
+/**
+ * ScreenInfoAction, a KeyStroke in disguise, this class contains the reported position of the screen cursor.
+ */
+public class ScreenInfoAction extends KeyStroke {
+    private final TerminalPosition position;
+
+    /**
+     * Constructs a ScreenInfoAction based on a location on the screen
+     * @param position the TerminalPosition reported from terminal
+     */
+    public ScreenInfoAction(TerminalPosition position) {
+        super(KeyType.CursorLocation);
+        this.position = position;
+    }
+
+    /**
+     * The location of the mouse cursor when this event was generated.
+     * @return Location of the mouse cursor
+     */
+    public TerminalPosition getPosition() {
+        return position;
+    }
+
+    @Override
+    public String toString() {
+        return "ScreenInfoAction{position=" + position + '}';
+    }
+}


### PR DESCRIPTION
I think I've finished it now.

This is what Lanterna would look like with a CharacterPattern as I'd have preferred.

As by-products of this change:
 * cursor position reporting (and thus terminal size query) is somewhat cleaner now
 * some new control- and alt-key combinations are now supported (e.g.: Alt-#, Ctrl-\\ ).
 * got rid of regex-matching in Pattern classes
 * ScreenInfoCharacterPattern now uses EscapeSequenceCharacterPattern for the hard work

