### PR TITLE
Localization proposal for short labels (OK, Yes, No, etc.)

### DIFF
--- a/src/main/java/com/googlecode/lanterna/bundle/BundleLocator.java
+++ b/src/main/java/com/googlecode/lanterna/bundle/BundleLocator.java
@@ -1,0 +1,58 @@
+package com.googlecode.lanterna.bundle;
+
+import java.security.PrivilegedAction;
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+
+/**
+ * This class permits to deal easily with bundles.
+ * @author silveryocha
+ */
+public abstract class BundleLocator {
+
+    private final String bundleName;
+    private final Map<Locale, ResourceBundle> bundles = new HashMap<Locale, ResourceBundle>();
+    private static final ClassLoader loader = BundleLocator.class.getClassLoader();
+
+    /**
+     * Hidden constructor.
+     * @param bundleName the name of the bundle.
+     */
+    protected BundleLocator(final String bundleName) {
+        this.bundleName = bundleName;
+    }
+
+    /**
+     * Method that centralizes the way to get the bundle key associated value.
+     * @param locale the locale.
+     * @param key the key searched for.
+     * @param parameters the parameters to apply to the value associated to the key.
+     * @return the formatted value associated to the given key. Empty string if no value exists for
+     * the given key.
+     */
+    protected String getBundleKeyValue(Locale locale, String key, Object... parameters) {
+        String value = null;
+        try {
+            value = getBundle(locale).getString(key);
+        } catch (Exception ignore) {
+        }
+        return value != null ? MessageFormat.format(value, parameters) : null;
+    }
+
+    /**
+     * Loads the right bundle, taking into account the overrated file if any.
+     * @param locale the locale.
+     * @return the instance of the bundle.
+     */
+    private ResourceBundle getBundle(Locale locale) {
+        ResourceBundle bundle = bundles.get(locale);
+        if (bundle == null) {
+            bundle = ResourceBundle.getBundle(bundleName, locale, loader);
+            bundles.put(locale, bundle);
+        }
+        return bundle;
+    }
+}

--- a/src/main/java/com/googlecode/lanterna/bundle/BundleLocator.java
+++ b/src/main/java/com/googlecode/lanterna/bundle/BundleLocator.java
@@ -14,7 +14,6 @@ import java.util.ResourceBundle;
 public abstract class BundleLocator {
 
     private final String bundleName;
-    private final Map<Locale, ResourceBundle> bundles = new HashMap<Locale, ResourceBundle>();
     private static final ClassLoader loader = BundleLocator.class.getClassLoader();
 
     /**
@@ -26,7 +25,7 @@ public abstract class BundleLocator {
     }
 
     /**
-     * Method that centralizes the way to get the bundle key associated value.
+     * Method that centralizes the way to get the value associated to a bundle key.
      * @param locale the locale.
      * @param key the key searched for.
      * @param parameters the parameters to apply to the value associated to the key.
@@ -43,16 +42,12 @@ public abstract class BundleLocator {
     }
 
     /**
-     * Loads the right bundle, taking into account the overrated file if any.
+     * Gets the right bundle.<br/>
+     * A cache is handled as well as the concurrent accesses.
      * @param locale the locale.
      * @return the instance of the bundle.
      */
     private ResourceBundle getBundle(Locale locale) {
-        ResourceBundle bundle = bundles.get(locale);
-        if (bundle == null) {
-            bundle = ResourceBundle.getBundle(bundleName, locale, loader);
-            bundles.put(locale, bundle);
-        }
-        return bundle;
+        return ResourceBundle.getBundle(bundleName, locale, loader);
     }
 }

--- a/src/main/java/com/googlecode/lanterna/bundle/LocalizedUiBundle.java
+++ b/src/main/java/com/googlecode/lanterna/bundle/LocalizedUiBundle.java
@@ -1,0 +1,24 @@
+package com.googlecode.lanterna.bundle;
+
+import java.util.Locale;
+
+/**
+ * This class permits to get easily localized strings about the UI.
+ * @author silveryocha
+ */
+public class LocalizedUiBundle extends BundleLocator {
+
+    private static final LocalizedUiBundle me = new LocalizedUiBundle("multilang.lanterna-ui");
+
+    public static String get(String key, String... parameters) {
+        return get(Locale.getDefault(), key, parameters);
+    }
+
+    public static String get(Locale locale, String key, String... parameters) {
+        return me.getBundleKeyValue(locale, key, parameters);
+    }
+
+    private LocalizedUiBundle(final String bundleName) {
+        super(bundleName);
+    }
+}

--- a/src/main/java/com/googlecode/lanterna/gui2/LocalizedString.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/LocalizedString.java
@@ -1,0 +1,35 @@
+package com.googlecode.lanterna.gui2;
+
+import com.googlecode.lanterna.bundle.LocalizedUiBundle;
+
+import java.util.Locale;
+
+/**
+ * Set of predefined localized string.<br/>
+ * All this strings are localized by using {@link LocalizedUiBundle}.<br/>
+ * Changing the locale by calling {@link Locale#setDefault(Locale)}.
+ * @author silveryocha.
+ */
+public class LocalizedString {
+
+    public final static LocalizedString OK = new LocalizedString("short.label.ok");
+    public final static LocalizedString Cancel = new LocalizedString("short.label.cancel");
+    public final static LocalizedString Yes = new LocalizedString("short.label.yes");
+    public final static LocalizedString No = new LocalizedString("short.label.no");
+    public final static LocalizedString Close = new LocalizedString("short.label.close");
+    public final static LocalizedString Abort = new LocalizedString("short.label.abort");
+    public final static LocalizedString Ignore = new LocalizedString("short.label.ignore");
+    public final static LocalizedString Retry = new LocalizedString("short.label.retry");
+    public final static LocalizedString Continue = new LocalizedString("short.label.continue");
+
+    private final String bundleKey;
+
+    private LocalizedString(final String bundleKey) {
+        this.bundleKey = bundleKey;
+    }
+
+    @Override
+    public String toString() {
+        return LocalizedUiBundle.get(Locale.getDefault(), bundleKey);
+    }
+}

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialog.java
@@ -54,7 +54,7 @@ public class ActionListDialog extends DialogWindow {
         if(canCancel) {
             Panel buttonPanel = new Panel();
             buttonPanel.setLayoutManager(new GridLayout(2).setHorizontalSpacing(1));
-            buttonPanel.addComponent(new Button("Cancel", new Runnable() {
+            buttonPanel.addComponent(new Button(LocalizedString.Cancel.toString(), new Runnable() {
                 @Override
                 public void run() {
                     onCancel();

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/FileDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/FileDialog.java
@@ -103,7 +103,7 @@ public class FileDialog extends DialogWindow {
         okButton = new Button(actionLabel, new OkHandler());
         Panels.grid(2,
                 okButton,
-                new Button("Cancel", new CancelHandler()))
+                new Button(LocalizedString.Cancel.toString(), new CancelHandler()))
                 .setLayoutData(GridLayout.createLayoutData(GridLayout.Alignment.END, GridLayout.Alignment.CENTER, false, false, 2, 1))
                 .addTo(contentPane);
 

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/FileDialogBuilder.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/FileDialogBuilder.java
@@ -1,6 +1,7 @@
 package com.googlecode.lanterna.gui2.dialogs;
 
 import com.googlecode.lanterna.TerminalSize;
+import com.googlecode.lanterna.gui2.LocalizedString;
 
 import java.io.File;
 
@@ -16,7 +17,7 @@ public class FileDialogBuilder extends AbstractDialogBuilder<FileDialogBuilder, 
 
     public FileDialogBuilder() {
         super("FileDialog");
-        actionLabel = "OK";
+        actionLabel = LocalizedString.OK.toString();
         suggestedSize = new TerminalSize(45, 10);
         showHiddenDirectories = false;
         selectedFile = null;

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/ListSelectDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/ListSelectDialog.java
@@ -56,7 +56,7 @@ public class ListSelectDialog<T> extends DialogWindow {
         if(canCancel) {
             Panel buttonPanel = new Panel();
             buttonPanel.setLayoutManager(new GridLayout(2).setHorizontalSpacing(1));
-            buttonPanel.addComponent(new Button("Cancel", new Runnable() {
+            buttonPanel.addComponent(new Button(LocalizedString.Cancel.toString(), new Runnable() {
                 @Override
                 public void run() {
                     onCancel();

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/MessageDialogButton.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/MessageDialogButton.java
@@ -1,16 +1,29 @@
 package com.googlecode.lanterna.gui2.dialogs;
 
+import com.googlecode.lanterna.gui2.LocalizedString;
+
 /**
  * Created by martin on 21/06/15.
  */
 public enum MessageDialogButton {
-    OK,
-    Cancel,
-    Yes,
-    No,
-    Close,
-    Abort,
-    Ignore,
-    Retry,
-    Continue,
+    OK(LocalizedString.OK),
+    Cancel(LocalizedString.Cancel),
+    Yes(LocalizedString.Yes),
+    No(LocalizedString.No),
+    Close(LocalizedString.Close),
+    Abort(LocalizedString.Abort),
+    Ignore(LocalizedString.Ignore),
+    Retry(LocalizedString.Retry),
+    Continue(LocalizedString.Continue);
+
+    private final LocalizedString label;
+
+    MessageDialogButton(final LocalizedString label) {
+        this.label = label;
+    }
+
+    @Override
+    public String toString() {
+        return label.toString();
+    }
 }

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/TextInputDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/TextInputDialog.java
@@ -35,13 +35,13 @@ public class TextInputDialog extends DialogWindow {
 
         Panel buttonPanel = new Panel();
         buttonPanel.setLayoutManager(new GridLayout(2).setHorizontalSpacing(1));
-        buttonPanel.addComponent(new Button("OK", new Runnable() {
+        buttonPanel.addComponent(new Button(LocalizedString.OK.toString(), new Runnable() {
             @Override
             public void run() {
                 onOK();
             }
         }).setLayoutData(GridLayout.createLayoutData(GridLayout.Alignment.CENTER, GridLayout.Alignment.CENTER, true, false)));
-        buttonPanel.addComponent(new Button("Cancel", new Runnable() {
+        buttonPanel.addComponent(new Button(LocalizedString.Cancel.toString(), new Runnable() {
             @Override
             public void run() {
                 onCancel();

--- a/src/main/java/com/googlecode/lanterna/terminal/DefaultTerminalFactory.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/DefaultTerminalFactory.java
@@ -119,11 +119,12 @@ public final class DefaultTerminalFactory implements TerminalFactory {
      * Sets a hint to the TerminalFactory of what size to use when creating the terminal. Most terminals are not created
      * on request but for example the SwingTerminal and SwingTerminalFrame are and this value will be passed down on
      * creation.
-     *
      * @param initialTerminalSize Size (in rows and columns) of the newly created terminal
+     * @return Reference to itself, so multiple .set-calls can be chained
      */
-    public void setInitialTerminalSize(TerminalSize initialTerminalSize) {
+    public DefaultTerminalFactory setInitialTerminalSize(TerminalSize initialTerminalSize) {
         this.initialTerminalSize = initialTerminalSize;
+        return this;
     }
 
     /**

--- a/src/main/resources/multilang/lanterna-ui.properties
+++ b/src/main/resources/multilang/lanterna-ui.properties
@@ -1,0 +1,10 @@
+short.label.ok=OK
+short.label.cancel=Cancel
+short.label.yes=Yes
+short.label.no=No
+short.label.close=Close
+short.label.abort=Abort
+short.label.ignore=Ignore
+short.label.retry=Retry
+short.label.continue=Continue
+short.label.open=Open

--- a/src/main/resources/multilang/lanterna-ui_de.properties
+++ b/src/main/resources/multilang/lanterna-ui_de.properties
@@ -1,0 +1,10 @@
+short.label.ok=Ok
+short.label.cancel=Abbrechen
+short.label.yes=Ja
+short.label.no=Nein
+short.label.close=Schließen
+short.label.abort=Beenden
+short.label.ignore=Ignorieren
+short.label.retry=Wiederholen
+short.label.continue=Weiter
+short.label.open=Öffnen

--- a/src/main/resources/multilang/lanterna-ui_fr.properties
+++ b/src/main/resources/multilang/lanterna-ui_fr.properties
@@ -5,6 +5,6 @@ short.label.no=Non
 short.label.close=Fermer
 short.label.abort=Abandonner
 short.label.ignore=Ignorer
-short.label.retry=Réessayer
+short.label.retry=RÃ©essayer
 short.label.continue=Continuer
 short.label.open=Ouvrir

--- a/src/main/resources/multilang/lanterna-ui_fr.properties
+++ b/src/main/resources/multilang/lanterna-ui_fr.properties
@@ -1,0 +1,10 @@
+short.label.ok=Ok
+short.label.cancel=Annuler
+short.label.yes=Oui
+short.label.no=Non
+short.label.close=Fermer
+short.label.abort=Abandonner
+short.label.ignore=Ignorer
+short.label.retry=Réessayer
+short.label.continue=Continuer
+short.label.open=Ouvrir


### PR DESCRIPTION
This PR is the result of the discussion on https://github.com/mabe02/lanterna/pull/191.

I'm sorry to propose it after one week and more while the refactoring was already done...

As the proposal of my first PR, the mechanism uses the built-in one provided by Java. But this time, it is more simple and righter.

For now, only the button labels are taken into account and there are two handled languages:
- the default one, English(lanterna-ui.properties)
- the French one (lanterna-ui_fr.properties)

To get another handled language, the linked lanterna-UI_XX.properties file must be added.
For example, to handle German language, lanterna-ui_de.properties must be created.

I have read your post-scriptum about https://transifex.com, and I think that it is a good way to get translations, but I'm not sure that it is a good thing to integrate it directly into lanterna as it is clearly WEB oriented. However, I'm not one hundred per cent sure but it seems possible to make a connection between a GitHub project to their WEB APIs. Maybe the bundle property files could be filled by this way...

I hope this PR can be interresting, or at least, may make other ideas emerge about the subject of Localization.