### PR TITLE
argument to stopScreen to control flushing of input

### DIFF
--- a/src/main/java/com/googlecode/lanterna/screen/TerminalScreen.java
+++ b/src/main/java/com/googlecode/lanterna/screen/TerminalScreen.java
@@ -102,17 +102,23 @@ public class TerminalScreen extends AbstractScreen {
     }
 
     @Override
-    public synchronized void stopScreen() throws IOException {
+    public void stopScreen() throws IOException {
+        stopScreen(true);
+    }
+    
+    public synchronized void stopScreen(boolean flush) throws IOException {
         if(!isStarted) {
             return;
         }
 
-        //Drain the input queue
-        KeyStroke keyStroke;
-        do {
-            keyStroke = pollInput();
+        if (flush) {
+            //Drain the input queue
+            KeyStroke keyStroke;
+            do {
+                keyStroke = pollInput();
+            }
+            while(keyStroke != null && keyStroke.getKeyType() != KeyType.EOF);
         }
-        while(keyStroke != null && keyStroke.getKeyType() != KeyType.EOF);
 
         getTerminal().exitPrivateMode();
         isStarted = false;


### PR DESCRIPTION
I'd like to be able to avoid flushing of the input buffer on exit.  This PR might just be a start - next step would be getting rid of the Bufferedreader in InputDecoder.