### PR TITLE
Quickfix to make Windows visible again.

### DIFF
--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractWindow.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractWindow.java
@@ -57,7 +57,7 @@ public abstract class AbstractWindow extends AbstractBasePane implements Window 
         super();
         this.title = title;
         this.textGUI = null;
-        this.visible = false;
+        this.visible = true;
         this.lastKnownPosition = null;
         this.lastKnownSize = null;
         this.lastKnownDecoratedSize = null;
@@ -113,6 +113,10 @@ public abstract class AbstractWindow extends AbstractBasePane implements Window 
         return visible;
     }
 
+    @Override
+    public void setVisible(boolean visible) {
+        this.visible = visible;
+    }
     @Override
     public void draw(TextGUIGraphics graphics) {
         if(!graphics.getSize().equals(lastKnownSize)) {

--- a/src/main/java/com/googlecode/lanterna/gui2/Window.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/Window.java
@@ -133,6 +133,15 @@ public interface Window extends BasePane {
     boolean isVisible();
 
     /**
+     * This values is optionally used by the window manager to decide if the windows should be drawn or not. In an
+     * invisible state, the window is still considered active in the TextGUI but just not drawn and not receiving any
+     * input events. Please note that window managers may choose not to implement this.
+     *
+     * @param visible whether the window should be visible or not
+     */
+    void setVisible(boolean visible);
+
+    /**
      * This method is used to determine if the window requires re-drawing. The most common cause for this is the some
      * of its components has changed and we need a re-draw to make these changes visible.
      * @return {@code true} if the window would like to be re-drawn, {@code false} if the window doesn't need


### PR DESCRIPTION
An even quicker fix would be to just initialize `visible` to `true` (in AbstarctWindow.java)

This PR does that, and also adds a setter `setVisible(boolean)` to Window.

An even more elaborate fix might leave initial visible at false, but set it to true when a Window is added to a TextGui. It makes a subtle difference, depending on what was the original motivation behind adding that flag.