### PR TITLE
FileDialog.java : adding other file System roots available

### DIFF
--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/FileDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/FileDialog.java
@@ -208,6 +208,19 @@ public class FileDialog extends DialogWindow {
                     reloadViews(directory.getAbsoluteFile().getParentFile());
                 }
             });
+        } else {
+            File[] roots = File.listRoots();
+            for (final File entry : roots) {
+                if (entry.canRead()) {
+                    directoryListBox.addItem('[' + entry.getPath() + ']', new Runnable() {
+                        @Override
+                        public void run() {
+                            FileDialog.this.directory = entry;
+                            reloadViews(entry);
+                        }
+                    });
+                }
+            }
         }
         for(final File entry: entries) {
             if(entry.isHidden() && !showHiddenFilesAndDirs) {


### PR DESCRIPTION
When filesystem root is reached other available roots are shown ( on windows other roots are the drives )