### PR TITLE
AbstractScreen shouldn't pad CJK. BasicImage already did.

### DIFF
--- a/src/main/java/com/googlecode/lanterna/screen/AbstractScreen.java
+++ b/src/main/java/com/googlecode/lanterna/screen/AbstractScreen.java
@@ -152,18 +152,6 @@ public abstract class AbstractScreen implements Screen {
             //This is the normal case, no special character
             backBuffer.setCharacterAt(column, row, screenCharacter);
         }
-
-        //Pad CJK character with a trailing space
-        if(TerminalTextUtils.isCharCJK(screenCharacter.getCharacter())) {
-            backBuffer.setCharacterAt(column + 1, row, screenCharacter.withCharacter(' '));
-        }
-        //If there's a CJK character immediately to our left, reset it
-        if(column > 0) {
-            TextCharacter cjkTest = backBuffer.getCharacterAt(column - 1, row);
-            if(cjkTest != null && TerminalTextUtils.isCharCJK(cjkTest.getCharacter())) {
-                backBuffer.setCharacterAt(column - 1, row, backBuffer.getCharacterAt(column - 1, row).withCharacter(' '));
-            }
-        }
     }
 
     @Override


### PR DESCRIPTION
I noticed that CJKScreenTest no longer showed any double-width characters.

The problem was CJK-padding at multiple layers:  At the bottom (BasicImage) it made sure that the character was padded, and that any double-width character immediately to the left of current position was removed.

Then, further up the call stack, AbstractScreen also tried to pad CJK, which meant it placed a space after it, which the BasicImage noticed to follow a CJK and thus removed the CJK.

This PR should fix it, and hopefully doesn't introduce regressions elsewhere.