### PR TITLE
add SGR.Italic ...

### DIFF
--- a/src/main/java/com/googlecode/lanterna/SGR.java
+++ b/src/main/java/com/googlecode/lanterna/SGR.java
@@ -66,5 +66,10 @@ public enum SGR {
      * Draws a circle around the text. Rarely supported.
      */
     CIRCLED,
+
+    /**
+     * Italic (cursive) text mode. Some Terminal seem to support it.
+     */
+    ITALIC,
     ;
 }

--- a/src/main/java/com/googlecode/lanterna/TerminalTextUtils.java
+++ b/src/main/java/com/googlecode/lanterna/TerminalTextUtils.java
@@ -369,6 +369,9 @@ public class TerminalTextUtils {
                 case 1:
                     target.enableModifiers(SGR.BOLD);
                     break;
+                case 3:
+                    target.enableModifiers(SGR.ITALIC);
+                    break;
                 case 4:
                     target.enableModifiers(SGR.UNDERLINE);
                     break;
@@ -381,6 +384,9 @@ public class TerminalTextUtils {
                 case 21: // both do. 21 seems more straightforward.
                 case 22:
                     target.disableModifiers(SGR.BOLD);
+                    break;
+                case 23:
+                    target.disableModifiers(SGR.ITALIC);
                     break;
                 case 24:
                     target.disableModifiers(SGR.UNDERLINE);

--- a/src/main/java/com/googlecode/lanterna/TextCharacter.java
+++ b/src/main/java/com/googlecode/lanterna/TextCharacter.java
@@ -197,6 +197,14 @@ public class TextCharacter {
     }
 
     /**
+     * Returns true if this TextCharacter has the italic modifier active
+     * @return {@code true} if this TextCharacter has the italic modifier active
+     */
+    public boolean isItalic() {
+        return modifiers.contains(SGR.ITALIC);
+    }
+
+    /**
      * Returns a new TextCharacter with the same colors and modifiers but a different underlying character
      * @param character Character the copy should have
      * @return Copy of this TextCharacter with different underlying character

--- a/src/main/java/com/googlecode/lanterna/terminal/ansi/ANSITerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/ansi/ANSITerminal.java
@@ -159,6 +159,9 @@ public abstract class ANSITerminal extends StreamBasedTerminal implements Extend
             case UNDERLINE:
                 writeCSISequenceToTerminal((byte) '4', (byte) 'm');
                 break;
+            case ITALIC:
+                writeCSISequenceToTerminal((byte) '3', (byte) 'm');
+                break;
         }
     }
 
@@ -188,6 +191,9 @@ public abstract class ANSITerminal extends StreamBasedTerminal implements Extend
                 break;
             case UNDERLINE:
                 writeCSISequenceToTerminal((byte) '2', (byte) '4', (byte) 'm');
+                break;
+            case ITALIC:
+                writeCSISequenceToTerminal((byte) '2', (byte) '3', (byte) 'm');
                 break;
         }
     }

--- a/src/main/java/com/googlecode/lanterna/terminal/swing/AWTTerminalFontConfiguration.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/swing/AWTTerminalFontConfiguration.java
@@ -238,6 +238,9 @@ public class AWTTerminalFontConfiguration {
                 normalFont = normalFont.deriveFont(Font.BOLD);
             }
         }
+        if (character.isItalic() ) {
+            normalFont = normalFont.deriveFont(Font.ITALIC);
+        }
         return normalFont;
     }
 


### PR DESCRIPTION
My belief is, that Italic is actually more widely supported by terminals than Fraktur and Circled.
At least, it seems to work in putty and gnome-terminal.
(Awt/Swing, and TextGraphicsWriter are also covered.)
