### PR TITLE
add quirk for Terminal emulator "Terminology".

### DIFF
--- a/src/main/java/com/googlecode/lanterna/input/MouseCharacterPattern.java
+++ b/src/main/java/com/googlecode/lanterna/input/MouseCharacterPattern.java
@@ -65,7 +65,7 @@ public class MouseCharacterPattern implements CharacterPattern {
                     actionType = MouseActionType.CLICK_RELEASE;
                 }
                 break;
-            case(2):
+            case(2): case(0):
                 if(button == 0) {
                     actionType = MouseActionType.MOVE;
                 }


### PR DESCRIPTION
Terminology's MOVE events have 0x1f as first parameter byte, so the
actionCode is 0 instead of 2.  This caused the MouseActionType to be
null and an NPE got thrown in ANSITerminal.filterMouseEvents.

Found during discussion of #277 