### PR TITLE
Don't crash if terminal doesn't respond in time.

### DIFF
--- a/src/main/java/com/googlecode/lanterna/terminal/ansi/ANSITerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/ansi/ANSITerminal.java
@@ -103,6 +103,9 @@ public abstract class ANSITerminal extends StreamBasedTerminal implements Extend
         reportPosition();
         restoreCursorPosition();
         TerminalPosition terminalPosition = waitForCursorPositionReport();
+        if (terminalPosition == null) {
+            terminalPosition = new TerminalPosition(80,24);
+        }
         return new TerminalSize(terminalPosition.getColumn(), terminalPosition.getRow());
     }
 
@@ -238,7 +241,11 @@ public abstract class ANSITerminal extends StreamBasedTerminal implements Extend
         reportPosition();
 
         // ANSI terminal positions are 1-indexed so top-left corner is 1x1 instead of 0x0, that's why we need to adjust it here
-        return waitForCursorPositionReport().withRelative(-1, -1);
+        TerminalPosition terminalPosition = waitForCursorPositionReport();
+        if (terminalPosition == null) {
+            terminalPosition = TerminalPosition.OFFSET_1x1;
+        }
+        return terminalPosition.withRelative(-1, -1);
     }
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/terminal/ansi/StreamBasedTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/ansi/StreamBasedTerminal.java
@@ -171,18 +171,19 @@ public abstract class StreamBasedTerminal extends AbstractTerminal {
     }
 
     /**
-     * Waits for up to 2 seconds for a terminal cursor position report to appear in the input stream. If the timeout
-     * expires, it throws {@code IllegalStateException}. You should have send the cursor position query already before
+     * Waits for up to 5 seconds for a terminal cursor position report to appear in the input stream. If the timeout
+     * expires, it will return null. You should have sent the cursor position query already before
      * calling this method.
-     * @return Current position of the cursor
+     * @return Current position of the cursor, or null if the terminal didn't report it in time.
      * @throws IOException If there was an I/O error
      */
     synchronized TerminalPosition waitForCursorPositionReport() throws IOException {
         long startTime = System.currentTimeMillis();
         TerminalPosition cursorPosition = lastReportedCursorPosition;
         while(cursorPosition == null) {
-            if(System.currentTimeMillis() - startTime > 2000) {
-                throw new IllegalStateException("Terminal didn't send any position report for 2 seconds, please file a bug with a reproduce!");
+            if(System.currentTimeMillis() - startTime > 5000) {
+                //throw new IllegalStateException("Terminal didn't send any position report for 5 seconds, please file a bug with a reproduce!");
+                return null;
             }
             KeyStroke keyStroke = readInput(false, false);
             if(keyStroke != null) {


### PR DESCRIPTION
This PR is more a request for discussion...

While playing with TerminalInputTest and mouse-capturing, it frequently happened that in the flood of mouse-events it missed the reply for the size query and the app crashed with IllegalStateException.  I don't know, whether the terminal just sent it too late, or missed sending the information at all, but it happened ways too often, while moving/dragging the mouse around.

This patch does three things:
 - wait up to 5 seconds instead of 2 seconds
 - if no reply found in waitForCursorPositionReport, return null instead of throwing up.
 - in ANSITerminal: deal with null by substituting dummy values: this could take further discussion. maybe we should try to just keep previous size, or just deliver "don't know" (aka: null) to users...
