### PR TITLE
Fixwarnings

### DIFF
--- a/src/main/java/com/googlecode/lanterna/graphics/AbstractTheme.java
+++ b/src/main/java/com/googlecode/lanterna/graphics/AbstractTheme.java
@@ -132,12 +132,12 @@ public abstract class AbstractTheme implements Theme {
         return windowDecorationRenderer;
     }
 
-    protected static <T> T stringToClass(String className, Class<T> type) {
+    protected static Object instanceByClassName(String className) {
         if(className == null || className.trim().isEmpty()) {
             return null;
         }
         try {
-            return (T)Class.forName(className).newInstance();
+            return Class.forName(className).newInstance();
         } catch (InstantiationException e) {
             throw new RuntimeException(e);
         } catch (IllegalAccessException e) {
@@ -290,6 +290,7 @@ public abstract class AbstractTheme implements Theme {
             return Boolean.parseBoolean(propertyValue);
         }
 
+        @SuppressWarnings("unchecked")
         @Override
         public <T extends Component> ComponentRenderer<T> getRenderer(Class<T> type) {
             String rendererClass = node.renderer;
@@ -301,7 +302,7 @@ public abstract class AbstractTheme implements Theme {
                     return new DefinitionImpl(node.parent).getRenderer(type);
                 }
             }
-            return stringToClass(rendererClass, ComponentRenderer.class);
+            return (ComponentRenderer<T>)instanceByClassName(rendererClass);
         }
     }
 
@@ -366,7 +367,7 @@ public abstract class AbstractTheme implements Theme {
     private static class ThemeTreeNode {
         private final Class<?> clazz;
         private final ThemeTreeNode parent;
-        private final Map<Class, ThemeTreeNode> childMap;
+        private final Map<Class<?>, ThemeTreeNode> childMap;
         private final Map<String, TextColor> foregroundMap;
         private final Map<String, TextColor> backgroundMap;
         private final Map<String, EnumSet<SGR>> sgrMap;
@@ -378,7 +379,7 @@ public abstract class AbstractTheme implements Theme {
         private ThemeTreeNode(Class<?> clazz, ThemeTreeNode parent) {
             this.clazz = clazz;
             this.parent = parent;
-            this.childMap = new HashMap<Class, ThemeTreeNode>();
+            this.childMap = new HashMap<Class<?>, ThemeTreeNode>();
             this.foregroundMap = new HashMap<String, TextColor>();
             this.backgroundMap = new HashMap<String, TextColor>();
             this.sgrMap = new HashMap<String, EnumSet<SGR>>();

--- a/src/main/java/com/googlecode/lanterna/graphics/PropertiesTheme.java
+++ b/src/main/java/com/googlecode/lanterna/graphics/PropertiesTheme.java
@@ -55,8 +55,8 @@ public final class PropertiesTheme implements Theme {
         rootNode = new ThemeTreeNode(null);
         rootNode.foregroundMap.put(STYLE_NORMAL, TextColor.ANSI.WHITE);
         rootNode.backgroundMap.put(STYLE_NORMAL, TextColor.ANSI.BLACK);
-        windowPostRenderer = stringToClass(properties.getProperty("postrenderer", ""), WindowPostRenderer.class);
-        windowDecorationRenderer = stringToClass(properties.getProperty("windowdecoration", ""), WindowDecorationRenderer.class);
+        windowPostRenderer = (WindowPostRenderer)instanceByClassName(properties.getProperty("postrenderer", ""));
+        windowDecorationRenderer = (WindowDecorationRenderer)instanceByClassName(properties.getProperty("windowdecoration", ""));
 
         for(String key: properties.stringPropertyNames()) {
             String definition = getDefinition(key);
@@ -139,12 +139,12 @@ public final class PropertiesTheme implements Theme {
         return windowDecorationRenderer;
     }
 
-    private static <T> T stringToClass(String className, Class<T> type) {
+    private static Object instanceByClassName(String className) {
         if(className == null || className.trim().isEmpty()) {
             return null;
         }
         try {
-            return (T)Class.forName(className).newInstance();
+            return Class.forName(className).newInstance();
         } catch (InstantiationException e) {
             throw new RuntimeException(e);
         } catch (IllegalAccessException e) {
@@ -229,9 +229,10 @@ public final class PropertiesTheme implements Theme {
             return Boolean.parseBoolean(propertyValue);
         }
 
+        @SuppressWarnings("unchecked")
         @Override
         public <T extends Component> ComponentRenderer<T> getRenderer(Class<T> type) {
-            return stringToClass(path.get(path.size() - 1).renderer, ComponentRenderer.class);
+            return (ComponentRenderer<T>)instanceByClassName(path.get(path.size() - 1).renderer);
         }
     }
 
@@ -291,7 +292,7 @@ public final class PropertiesTheme implements Theme {
     }
 
     private static class ThemeTreeNode {
-        private final ThemeTreeNode parent;
+        //private final ThemeTreeNode parent;
         private final Map<String, ThemeTreeNode> childMap;
         private final Map<String, TextColor> foregroundMap;
         private final Map<String, TextColor> backgroundMap;
@@ -302,7 +303,7 @@ public final class PropertiesTheme implements Theme {
         private String renderer;
 
         private ThemeTreeNode(ThemeTreeNode parent) {
-            this.parent = parent;
+            //this.parent = parent;
             childMap = new HashMap<String, ThemeTreeNode>();
             foregroundMap = new HashMap<String, TextColor>();
             backgroundMap = new HashMap<String, TextColor>();

--- a/src/main/java/com/googlecode/lanterna/graphics/PropertyTheme.java
+++ b/src/main/java/com/googlecode/lanterna/graphics/PropertyTheme.java
@@ -63,8 +63,8 @@ public class PropertyTheme extends AbstractTheme {
      */
     public PropertyTheme(Properties properties, boolean ignoreUnknownClasses) {
 
-        super(stringToClass(properties.getProperty("postrenderer", ""), WindowPostRenderer.class),
-                stringToClass(properties.getProperty("windowdecoration", ""), WindowDecorationRenderer.class));
+        super( (WindowPostRenderer)instanceByClassName(properties.getProperty("postrenderer", "")),
+               (WindowDecorationRenderer)instanceByClassName(properties.getProperty("windowdecoration", "")));
 
         for(String key: properties.stringPropertyNames()) {
             String definition = getDefinition(key);

--- a/src/main/java/com/googlecode/lanterna/graphics/SimpleTheme.java
+++ b/src/main/java/com/googlecode/lanterna/graphics/SimpleTheme.java
@@ -96,7 +96,7 @@ public class SimpleTheme implements Theme {
     }
 
     private final Definition defaultDefinition;
-    private final Map<Class, Definition> overrideDefinitions;
+    private final Map<Class<?>, Definition> overrideDefinitions;
     private WindowPostRenderer windowPostRenderer;
     private WindowDecorationRenderer windowDecorationRenderer;
 
@@ -108,7 +108,7 @@ public class SimpleTheme implements Theme {
      */
     public SimpleTheme(TextColor foreground, TextColor background, SGR... styles) {
         this.defaultDefinition = new Definition(new Style(foreground, background, styles));
-        this.overrideDefinitions = new HashMap<Class, Definition>();
+        this.overrideDefinitions = new HashMap<Class<?>, Definition>();
         this.windowPostRenderer = null;
         this.windowDecorationRenderer = null;
     }
@@ -135,7 +135,7 @@ public class SimpleTheme implements Theme {
      * @param styles SGR styles to apply for this override
      * @return The newly created {@link Definition} that corresponds to this override.
      */
-    public synchronized Definition addOverride(Class clazz, TextColor foreground, TextColor background, SGR... styles) {
+    public synchronized Definition addOverride(Class<?> clazz, TextColor foreground, TextColor background, SGR... styles) {
         Definition definition = new Definition(new Style(foreground, background, styles));
         overrideDefinitions.put(clazz, definition);
         return definition;
@@ -190,7 +190,7 @@ public class SimpleTheme implements Theme {
         private final Map<String, ThemeStyle> customStyles;
         private final Properties properties;
         private final Map<String, Character> characterMap;
-        private final Map<Class, RendererProvider> componentRendererMap;
+        private final Map<Class<?>, RendererProvider<?>> componentRendererMap;
         private boolean cursorVisible;
 
         private Definition(ThemeStyle normal) {
@@ -202,7 +202,7 @@ public class SimpleTheme implements Theme {
             this.customStyles = new HashMap<String, ThemeStyle>();
             this.properties = new Properties();
             this.characterMap = new HashMap<String, Character>();
-            this.componentRendererMap = new HashMap<Class, RendererProvider>();
+            this.componentRendererMap = new HashMap<Class<?>, RendererProvider<?>>();
             this.cursorVisible = true;
         }
 
@@ -375,9 +375,10 @@ public class SimpleTheme implements Theme {
             return this;
         }
 
+        @SuppressWarnings("unchecked")
         @Override
         public synchronized <T extends Component> ComponentRenderer<T> getRenderer(Class<T> type) {
-            RendererProvider rendererProvider = componentRendererMap.get(type);
+            RendererProvider<T> rendererProvider = (RendererProvider<T>)componentRendererMap.get(type);
             if(rendererProvider == null) {
                 return null;
             }

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractListBox.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractListBox.java
@@ -346,7 +346,7 @@ public abstract class AbstractListBox<V, T extends AbstractListBox<V, T>> extend
             //update the page size, used for page up and page down keys
             ThemeDefinition themeDefinition = listBox.getTheme().getDefinition(AbstractListBox.class);
             int componentHeight = graphics.getSize().getRows();
-            int componentWidth = graphics.getSize().getColumns();
+            //int componentWidth = graphics.getSize().getColumns();
             int selectedIndex = listBox.getSelectedIndex();
             List<V> items = listBox.getItems();
             ListItemRenderer<V,T> listItemRenderer = listBox.getListItemRenderer();

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractWindow.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractWindow.java
@@ -206,7 +206,7 @@ public abstract class AbstractWindow extends AbstractBasePane implements Window 
         this.lastKnownPosition = topLeft;
 
         // Fire listeners
-        for(BasePaneListener listener: getBasePaneListeners()) {
+        for(BasePaneListener<?> listener: getBasePaneListeners()) {
             if(listener instanceof WindowListener) {
                 ((WindowListener)listener).onMoved(this, oldPosition, topLeft);
             }
@@ -231,7 +231,7 @@ public abstract class AbstractWindow extends AbstractBasePane implements Window 
         }
 
         // Fire listeners
-        for(BasePaneListener listener: getBasePaneListeners()) {
+        for(BasePaneListener<?> listener: getBasePaneListeners()) {
             if(listener instanceof WindowListener) {
                 ((WindowListener)listener).onResized(this, oldSize, size);
             }

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractWindow.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractWindow.java
@@ -31,7 +31,7 @@ import java.util.*;
  * up the GUI externally by constructing a {@code BasicWindow} and adding components to it.
  * @author Martin
  */
-public abstract class AbstractWindow extends AbstractBasePane implements Window {
+public abstract class AbstractWindow extends AbstractBasePane<Window> implements Window {
     private String title;
     private WindowBasedTextGUI textGUI;
     private boolean visible;
@@ -268,4 +268,6 @@ public abstract class AbstractWindow extends AbstractBasePane implements Window 
             textGUI.waitForWindowToClose(this);
         }
     }
+
+    Window self() { return this; }
 }

--- a/src/main/java/com/googlecode/lanterna/gui2/MultiWindowTextGUI.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/MultiWindowTextGUI.java
@@ -164,7 +164,7 @@ public class MultiWindowTextGUI extends AbstractTextGUI implements WindowBasedTe
         }
         this.virtualScreen = screen;
         this.windowManager = windowManager;
-        this.backgroundPane = new AbstractBasePane() {
+        this.backgroundPane = new AbstractBasePane<BasePane>() {
             @Override
             public TextGUI getTextGUI() {
                 return MultiWindowTextGUI.this;
@@ -178,6 +178,8 @@ public class MultiWindowTextGUI extends AbstractTextGUI implements WindowBasedTe
             public TerminalPosition fromGlobal(TerminalPosition globalPosition) {
                 return globalPosition;
             }
+
+            BasePane self() { return this; }
         };
         this.backgroundPane.setComponent(background);
         this.windows = new LinkedList<Window>();

--- a/src/main/java/com/googlecode/lanterna/gui2/WindowShadowRenderer.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/WindowShadowRenderer.java
@@ -19,7 +19,6 @@
 package com.googlecode.lanterna.gui2;
 
 import com.googlecode.lanterna.*;
-import com.googlecode.lanterna.graphics.TextGraphics;
 import com.googlecode.lanterna.graphics.ThemeDefinition;
 import com.googlecode.lanterna.graphics.ThemedTextGraphics;
 

--- a/src/main/java/com/googlecode/lanterna/terminal/swing/AWTTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/swing/AWTTerminal.java
@@ -28,7 +28,6 @@ import com.googlecode.lanterna.terminal.IOSafeTerminal;
 import com.googlecode.lanterna.terminal.TerminalResizeListener;
 
 import java.awt.*;
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 

--- a/src/main/java/com/googlecode/lanterna/terminal/swing/AWTTerminalFrame.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/swing/AWTTerminalFrame.java
@@ -29,7 +29,6 @@ import com.googlecode.lanterna.TextColor;
 import com.googlecode.lanterna.terminal.TerminalResizeListener;
 
 import java.awt.*;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Set;

--- a/src/main/java/com/googlecode/lanterna/terminal/swing/GraphicalTerminalImplementation.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/swing/GraphicalTerminalImplementation.java
@@ -50,7 +50,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * @author martin
  */
-@SuppressWarnings("serial")
 abstract class GraphicalTerminalImplementation implements IOSafeTerminal {
     private final TerminalEmulatorDeviceConfiguration deviceConfiguration;
     private final TerminalEmulatorColorConfiguration colorConfiguration;

--- a/src/main/java/com/googlecode/lanterna/terminal/swing/ScrollingAWTTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/swing/ScrollingAWTTerminal.java
@@ -30,7 +30,6 @@ import com.googlecode.lanterna.terminal.TerminalResizeListener;
 import java.awt.*;
 import java.awt.event.AdjustmentEvent;
 import java.awt.event.AdjustmentListener;
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 /**

--- a/src/main/java/com/googlecode/lanterna/terminal/swing/ScrollingSwingTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/swing/ScrollingSwingTerminal.java
@@ -30,7 +30,6 @@ import com.googlecode.lanterna.terminal.TerminalResizeListener;
 import java.awt.*;
 import java.awt.event.AdjustmentEvent;
 import java.awt.event.AdjustmentListener;
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.swing.*;
 

--- a/src/main/java/com/googlecode/lanterna/terminal/swing/SwingTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/swing/SwingTerminal.java
@@ -29,7 +29,6 @@ import com.googlecode.lanterna.terminal.TerminalResizeListener;
 
 import javax.swing.*;
 import java.awt.*;
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -41,6 +40,7 @@ import java.util.concurrent.TimeUnit;
  * construct the object.
  * @author martin
  */
+@SuppressWarnings("serial")
 public class SwingTerminal extends JComponent implements IOSafeTerminal {
 
     private final SwingTerminalImplementation terminalImplementation;

--- a/src/main/java/com/googlecode/lanterna/terminal/swing/SwingTerminalFrame.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/swing/SwingTerminalFrame.java
@@ -29,7 +29,6 @@ import com.googlecode.lanterna.TextColor;
 import com.googlecode.lanterna.terminal.TerminalResizeListener;
 
 import java.awt.*;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Set;

--- a/src/main/java/com/googlecode/lanterna/terminal/virtual/DefaultVirtualTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/virtual/DefaultVirtualTerminal.java
@@ -24,7 +24,6 @@ import com.googlecode.lanterna.input.KeyStroke;
 import com.googlecode.lanterna.screen.TabBehaviour;
 import com.googlecode.lanterna.terminal.AbstractTerminal;
 
-import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;

--- a/src/test/java/com/googlecode/lanterna/graphics/PropertyThemeTest.java
+++ b/src/test/java/com/googlecode/lanterna/graphics/PropertyThemeTest.java
@@ -30,12 +30,12 @@ import java.util.Collections;
 import java.util.Properties;
 import static org.junit.Assert.*;
 
-public class PropertiesThemeTest {
+public class PropertyThemeTest {
 
     @Test
     public void emptyPropertiesGivesValidResults() {
         Properties properties = new Properties();
-        PropertiesTheme theme = new PropertiesTheme(properties);
+        PropertyTheme theme = new PropertyTheme(properties);
         ThemeDefinition definition = theme.getDefaultDefinition();
         assertNotNull(definition.getNormal());
         assertNotNull(definition.getActive());
@@ -57,7 +57,7 @@ public class PropertiesThemeTest {
         properties.load(inputStream);
         inputStream.close();
 
-        PropertiesTheme theme = new PropertiesTheme(properties);
+        PropertyTheme theme = new PropertyTheme(properties);
         ThemeDefinition defaultDefinition = theme.getDefaultDefinition();
         assertEquals(TextColor.ANSI.BLACK, defaultDefinition.getNormal().getForeground());
         assertEquals(TextColor.ANSI.WHITE, defaultDefinition.getNormal().getBackground());
@@ -71,8 +71,8 @@ public class PropertiesThemeTest {
     public void classWithoutThemePicksUpParentPackagesTheme() {
         Properties properties = new Properties();
         properties.setProperty("com.googlecode.lanterna.foreground", "yellow");
-        PropertiesTheme theme = new PropertiesTheme(properties);
-        ThemeDefinition definition = theme.getDefinition(PropertiesThemeTest.class);
+        PropertyTheme theme = new PropertyTheme(properties);
+        ThemeDefinition definition = theme.getDefinition(PropertyThemeTest.class);
         assertEquals(TextColor.ANSI.YELLOW, definition.getNormal().getForeground());
     }
 }

--- a/src/test/java/com/googlecode/lanterna/gui2/LineWrappingLabelTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/LineWrappingLabelTest.java
@@ -99,6 +99,7 @@ public class LineWrappingLabelTest extends TestBase {
                         case ArrowRight:
                             windowSize = windowSize.withRelativeColumns(1);
                             return true;
+                        default:
                     }
                 }
                 return false;

--- a/src/test/java/com/googlecode/lanterna/gui2/MultiWindowManagerTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/MultiWindowManagerTest.java
@@ -154,7 +154,7 @@ public class MultiWindowManagerTest extends TestBase {
             boolean isManaged = labelUnlockWindow.getText().equals("true");
             isManaged = !isManaged;
             if(isManaged) {
-                setHints(Collections.EMPTY_LIST);
+                setHints(Collections.<Hint> emptyList());
             }
             else {
                 setHints(Collections.singletonList(Hint.FIXED_SIZE));
@@ -203,6 +203,7 @@ public class MultiWindowManagerTest extends TestBase {
                         }
                         handled = true;
                         break;
+                    default:
                 }
             }
             return handled;

--- a/src/test/java/com/googlecode/lanterna/issue/Issue216.java
+++ b/src/test/java/com/googlecode/lanterna/issue/Issue216.java
@@ -47,7 +47,7 @@ public class Issue216 {
         panel.addComponent(new TextBox());
 
         panel.addComponent(new Label("Table"));
-        final Table table = new Table<String>("Test");
+        final Table<String> table = new Table<String>("Test");
         final TableModel<String> tableModel = table.getTableModel();
         tableModel.addRow("hi");
         panel.addComponent(table);

--- a/src/test/java/com/googlecode/lanterna/screen/ScreenTriangleTest.java
+++ b/src/test/java/com/googlecode/lanterna/screen/ScreenTriangleTest.java
@@ -19,7 +19,6 @@
 package com.googlecode.lanterna.screen;
 
 import com.googlecode.lanterna.TestTerminalFactory;
-import com.googlecode.lanterna.graphics.AbstractTextGraphics;
 import com.googlecode.lanterna.graphics.DoublePrintingTextGraphics;
 import com.googlecode.lanterna.graphics.TextGraphics;
 import com.googlecode.lanterna.input.KeyStroke;

--- a/src/test/java/com/googlecode/lanterna/screen/SimpleScreenTest.java
+++ b/src/test/java/com/googlecode/lanterna/screen/SimpleScreenTest.java
@@ -120,6 +120,7 @@ public class SimpleScreenTest {
                         screen.setCursorPosition(screen.getCursorPosition().withRelativeColumn(1));
                         break;
                     }
+                default:
             }
 
             screen.refresh();

--- a/src/test/java/com/googlecode/lanterna/terminal/SimpleTerminalTest.java
+++ b/src/test/java/com/googlecode/lanterna/terminal/SimpleTerminalTest.java
@@ -141,6 +141,7 @@ public class SimpleTerminalTest {
                             break;
                     }
                     break;
+                default:
             }
             terminal.flush();
         }

--- a/src/test/java/com/googlecode/lanterna/terminal/TerminalTextGraphicsTest.java
+++ b/src/test/java/com/googlecode/lanterna/terminal/TerminalTextGraphicsTest.java
@@ -19,7 +19,6 @@
 package com.googlecode.lanterna.terminal;
 
 import com.googlecode.lanterna.*;
-import com.googlecode.lanterna.graphics.AbstractTextGraphics;
 import com.googlecode.lanterna.graphics.DoublePrintingTextGraphics;
 import com.googlecode.lanterna.graphics.TextGraphics;
 


### PR DESCRIPTION
- unused imports: removed
- unused field and local var: commented out
- raw usages of Class and Table: add `<?>` and `<String>` respectively
- stringToClass method promised more than it could handle (failed on generics): simplified to just return Object and let the calling code do the type casting.
- getRenderer() methods: hush up generics-warnings. (dynamic loading of instances just cannot ever be generics-clean)
- made AbstractBasePane generic to serve both BasePanes and Windows alike - required adding a self() method.
- PropertiesTheme is deprecated: port PropertiesThemeTest to PropertyThemeTest.
- warnings about serial id for Serializable classes: hushed up.
- warnings about missing enum cases in switches: add empty default label - we really don't want to handle all possible values in handleInput/handleKeyStroke methods.
- `Collections.EMPTY_LIST`: changed to `Collections.<Hint>emptyList()`

two warnings **not** fixed here: deprecation warning for DoNotAutoClose is fixed in PR 283