### PR TITLE
Ctrl h backspace

### DIFF
--- a/src/main/java/com/googlecode/lanterna/input/CtrlAltAndCharacterPattern.java
+++ b/src/main/java/com/googlecode/lanterna/input/CtrlAltAndCharacterPattern.java
@@ -37,7 +37,7 @@ public class CtrlAltAndCharacterPattern implements CharacterPattern {
             return Matching.NOT_YET; // maybe later
         }
         char ch = seq.get(1);
-        if (ch < 32) {
+        if (ch < 32 && ch != 0x08) {
             // Control-chars: exclude Esc(^[), but still include ^\, ^], ^^ and ^_
             char ctrlCode;
             switch (ch) {
@@ -50,6 +50,9 @@ public class CtrlAltAndCharacterPattern implements CharacterPattern {
             default: ctrlCode = (char)('a' - 1 + ch);
             }
             KeyStroke ks = new KeyStroke( ctrlCode, true, true);
+            return new Matching( ks ); // yep
+        } else if (ch == 0x7f || ch == 0x08) {
+            KeyStroke ks = new KeyStroke( KeyType.Backspace, false, true);
             return new Matching( ks ); // yep
         } else {
             return null; // nope

--- a/src/main/java/com/googlecode/lanterna/input/CtrlAndCharacterPattern.java
+++ b/src/main/java/com/googlecode/lanterna/input/CtrlAndCharacterPattern.java
@@ -36,7 +36,7 @@ public class CtrlAndCharacterPattern implements CharacterPattern {
             // Control-chars: exclude lf,cr,Tab,Esc(^[), but still include ^\, ^], ^^ and ^_
             char ctrlCode;
             switch (ch) {
-            case '\n': case '\r': case '\t':
+            case '\n': case '\r': case '\t': case 0x08:
             case KeyDecodingProfile.ESC_CODE: return null; // nope
             case 0:  /* ^@ */ ctrlCode = ' '; break;
             case 28: /* ^\ */ ctrlCode = '\\'; break;

--- a/src/main/java/com/googlecode/lanterna/input/DefaultKeyDecodingProfile.java
+++ b/src/main/java/com/googlecode/lanterna/input/DefaultKeyDecodingProfile.java
@@ -40,6 +40,7 @@ public class DefaultKeyDecodingProfile implements KeyDecodingProfile {
                                 new BasicCharacterPattern(new KeyStroke(KeyType.Enter), '\n'),
                                 new BasicCharacterPattern(new KeyStroke(KeyType.Enter), '\r', '\u0000'), //OS X
                                 new BasicCharacterPattern(new KeyStroke(KeyType.Backspace), (char) 0x7f),
+                                new BasicCharacterPattern(new KeyStroke(KeyType.Backspace), (char) 0x08),
                                 new BasicCharacterPattern(new KeyStroke(KeyType.F1), ESC_CODE, '[', '[', 'A'), //Linux
                                 new BasicCharacterPattern(new KeyStroke(KeyType.F2), ESC_CODE, '[', '[', 'B'), //Linux
                                 new BasicCharacterPattern(new KeyStroke(KeyType.F3), ESC_CODE, '[', '[', 'C'), //Linux

--- a/src/main/java/com/googlecode/lanterna/input/KeyStroke.java
+++ b/src/main/java/com/googlecode/lanterna/input/KeyStroke.java
@@ -181,10 +181,38 @@ public class KeyStroke {
 
     @Override
     public String toString() {
-        return "KeyStroke{" + "keyType=" + keyType + ", character=" + character + 
-                ", ctrlDown=" + ctrlDown + 
-                ", altDown=" + altDown + 
-                ", shiftDown=" + shiftDown + '}';
+        StringBuilder sb = new StringBuilder();
+        sb.append("KeyStroke{keytype=").append(keyType);
+        if (character != null) {
+            char ch = character;
+            sb.append(", character='");
+            switch (ch) {
+            // many of these cases can only happen through user code:
+            case 0x00: sb.append("^@"); break;
+            case 0x08: sb.append("\\b"); break;
+            case 0x09: sb.append("\\t"); break;
+            case 0x0a: sb.append("\\n"); break;
+            case 0x0d: sb.append("\\r"); break;
+            case 0x1b: sb.append("^["); break;
+            case 0x1c: sb.append("^\\"); break;
+            case 0x1d: sb.append("^]"); break;
+            case 0x1e: sb.append("^^"); break;
+            case 0x1f: sb.append("^_"); break;
+            default:
+                if (ch <= 26) {
+                    sb.append('^').append((char)(ch+64));
+                } else { sb.append(ch); }
+            }
+            sb.append('\'');
+        }
+        if (ctrlDown || altDown || shiftDown) {
+            String sep=""; sb.append(", modifiers=[");
+            if (ctrlDown) {  sb.append(sep).append("ctrl"); sep=","; }
+            if (altDown) {   sb.append(sep).append("alt"); sep=","; }
+            if (shiftDown) { sb.append(sep).append("shift"); sep=","; }
+            sb.append("]");
+        }
+        return sb.append('}').toString();
     }
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/terminal/ansi/StreamBasedTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/ansi/StreamBasedTerminal.java
@@ -227,7 +227,7 @@ public abstract class StreamBasedTerminal extends AbstractTerminal {
             try {
                 KeyStroke key = inputDecoder.getNextCharacter(blocking);
                 ScreenInfoAction report = ScreenInfoCharacterPattern.tryToAdopt(key);
-                if(report != null) {
+                if (lastReportedCursorPosition == null && report != null) {
                     lastReportedCursorPosition = report.getPosition();
                 }
                 else {

--- a/src/test/java/com/googlecode/lanterna/terminal/TerminalInputTest.java
+++ b/src/test/java/com/googlecode/lanterna/terminal/TerminalInputTest.java
@@ -54,7 +54,7 @@ public class TerminalInputTest {
             }
 
             rawTerminal.setCursorPosition(0, currentRow++);
-            putString(rawTerminal, key.toString().replaceAll("\n", "\\\\n"));
+            putString(rawTerminal, key.toString());
 
             if(currentRow >= rawTerminal.getTerminalSize().getRows()) {
                 currentRow = 0;


### PR DESCRIPTION
The number of Terminal programs that default to ^H for Backspace is still "too damn high" to ignore it.

The downside of accepting Ctrl-H as a second Backspace is, that applications cannot treat Ctrl-H differently from ^?, but then again, they probably shouldn't, anyway.

the second commit deals with Esc-prefixed ^H and ^?.  Previously, Esc ^H would fall back to a single character with ctrl+alt, while Esc ^? would have been two separate key strokes Esc and Backspace.

@mabe02, it's your decision...