### PR TITLE
Fix bug on LinearLayout with empty containers

### DIFF
--- a/src/main/java/com/googlecode/lanterna/gui2/LinearLayout.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/LinearLayout.java
@@ -135,7 +135,7 @@ public class LinearLayout implements LayoutManager {
             height += preferredSize.getRows();
         }
         height += spacing * (components.size() - 1);
-        return new TerminalSize(maxWidth, height);
+        return new TerminalSize(maxWidth, Math.max(0, height));
     }
 
     private TerminalSize getPreferredSizeHorizontally(List<Component> components) {
@@ -149,7 +149,7 @@ public class LinearLayout implements LayoutManager {
             width += preferredSize.getColumns();
         }
         width += spacing * (components.size() - 1);
-        return new TerminalSize(width, maxHeight);
+        return new TerminalSize(Math.max(0,width), maxHeight);
     }
 
     @Override


### PR DESCRIPTION
This fixes a small bug in LinearLayout: if the container is empty, it creates a TerminalSize with -1, which crashes.