### PR TITLE
Only check visible windows for invalidness

### DIFF
--- a/src/main/java/com/googlecode/lanterna/gui2/MultiWindowTextGUI.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/MultiWindowTextGUI.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of lanterna (http://code.google.com/p/lanterna/).
- * 
+ *
  * lanterna is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  * Copyright (C) 2010-2017 Martin Berglund
  */
 package com.googlecode.lanterna.gui2;
@@ -191,7 +191,7 @@ public class MultiWindowTextGUI extends AbstractTextGUI implements WindowBasedTe
     @Override
     public synchronized boolean isPendingUpdate() {
         for(Window window: windows) {
-            if(window.isInvalid()) {
+            if(window.isVisible() && window.isInvalid()) {
                 return true;
             }
         }


### PR DESCRIPTION
Currently the `WindowTextGUI` only draws visible windows (since #201). Unfortunately this introduced a bug which caused lanterna redrawing until all windows are visible. This PR checks whether a window is invalid **and** visible, which should prevent this from happening.