### PR TITLE
UnixTerminal should now close properly

### DIFF
--- a/src/main/java/com/googlecode/lanterna/terminal/ansi/UnixTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/ansi/UnixTerminal.java
@@ -165,4 +165,12 @@ public class UnixTerminal extends UnixLikeTTYTerminal {
         
         return super.findTerminalSize();
     }
+    
+    @Override
+    public void close() throws IOException{
+        super.close();
+        restoreTerminalSettings();
+        keyEchoEnabled(true);
+        keyStrokeSignalsEnabled(true);
+    }
 }


### PR DESCRIPTION
 UnixTerminal should now close properly: restoring keyEcho, keyStrokeSignals and terminalSettings.
**Please don't merge this PR without reviewing it, as I don't know if I did it properly.**
(I tested it and it works against my needs though)
Should fix #305 