### PR TITLE
Bugfix: resizing terminals not working in some layout managers

### DIFF
--- a/src/main/java/com/googlecode/lanterna/terminal/swing/AWTTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/swing/AWTTerminal.java
@@ -192,6 +192,12 @@ public class AWTTerminal extends Panel implements IOSafeTerminal {
         terminalImplementation.paintComponent(componentGraphics);
     }
 
+    @Override
+    public void setBounds(int x, int y, int width, int height) {
+        super.setBounds(x, y, width, height);
+        terminalImplementation.setComponentBounds(x, y, width, height);
+    }
+
     // Terminal methods below here, just forward to the implementation
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/terminal/swing/GraphicalTerminalImplementation.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/swing/GraphicalTerminalImplementation.java
@@ -459,6 +459,15 @@ abstract class GraphicalTerminalImplementation implements IOSafeTerminal {
         //System.out.println("Updated backbuffer in " + (System.currentTimeMillis() - startTime) + " ms");
     }
 
+    void setComponentBounds(int x, int y, int width, int height) {
+    	if (width >= 0 && height >= 0) {
+	        int columns = width / getFontWidth();
+	        int rows = height / getFontHeight();
+	        TerminalSize terminalSize = virtualTerminal.getTerminalSize().withColumns(columns).withRows(rows);
+	        virtualTerminal.setTerminalSize(terminalSize);
+    	}
+    }
+
     private void buildDirtyCellsLookupTable(int firstRowOffset, int lastRowOffset) {
         if(virtualTerminal.isWholeBufferDirtyThenReset() || needFullRedraw) {
             dirtyCellsLookupTable.setAllDirty();

--- a/src/main/java/com/googlecode/lanterna/terminal/swing/SwingTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/swing/SwingTerminal.java
@@ -183,6 +183,12 @@ public class SwingTerminal extends JComponent implements IOSafeTerminal {
         terminalImplementation.paintComponent(componentGraphics);
     }
 
+    @Override
+    public void setBounds(int x, int y, int width, int height) {
+        super.setBounds(x, y, width, height);
+        terminalImplementation.setComponentBounds(x, y, width, height);
+    }
+
     ////////////////////////////////////////////////////////////////////////////////
     // Terminal methods below here, just forward to the implementation
 


### PR DESCRIPTION
Bugfix for resizing Terminals in layout managers that ask for preferred size, like BorderLayout.
If we put a Terminal inside the centre region of a Border layout, it stretches horizontally and vertically when resized.
However, the Terminal size (character size) remains the same as before resizing.
This happens because before painting, the layout manager asks for the Terminal preferred size (which has the old size value).
What needs to be done is to update the terminal size as soon as the Terminal is resized (in the setBounds() call).
I hope this description makes sense.
