### PR TITLE
Make read() block in TelnetTerminal

### DIFF
--- a/src/main/java/com/googlecode/lanterna/terminal/ansi/TelnetTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/ansi/TelnetTerminal.java
@@ -255,8 +255,11 @@ public class TelnetTerminal extends ANSITerminal {
         @Override
         @SuppressWarnings("NullableProblems")   //I can't find the correct way to fix this!
         public int read(byte[] b, int off, int len) throws IOException {
-            if(inputStream.available() > 0) {
-                fillBuffer();
+            if(available() == 0) {
+               // There was nothing in the buffer and the underlying
+               // stream has nothing available, so do a blocking read
+               // from the stream.
+               fillBuffer();
             }
             if(bytesInBuffer == 0) {
                 return -1;

--- a/src/test/java/com/googlecode/lanterna/terminal/TelnetTerminalTest.java
+++ b/src/test/java/com/googlecode/lanterna/terminal/TelnetTerminalTest.java
@@ -65,6 +65,10 @@ public class TelnetTerminalTest {
                     });
                     size = terminal.getTerminalSize();
 
+                    terminal.setCursorPosition(3, 3);
+                    printString(terminal, "Press any key to start");
+                    terminal.readInput(); // Test blocking input
+
                     while(true) {
                         KeyStroke key = terminal.pollInput();
                         if(key != null) {


### PR DESCRIPTION
I took a stab at fixing #332 ("readInput on Terminal from TelnetTerminalServer returns immediate EOF"). This also adds a demonstration of blocking input to TelnetTerminalTest.

Thanks for locating the code that needed to change, @avl42!

Please review carefully, as there is lots that I don't understand about the TELNET protocol and the Lanterna codebase.