### PR TITLE
Allow empty action list in ActionListDialog

### DIFF
--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialog.java
@@ -37,9 +37,6 @@ public class ActionListDialog extends DialogWindow {
             List<Runnable> actions) {
 
         super(title);
-        if(actions.isEmpty()) {
-            throw new IllegalStateException("ActionListDialog needs at least one item");
-        }
 
         ActionListBox listBox = new ActionListBox(actionListPreferredSize);
         for(final Runnable action: actions) {


### PR DESCRIPTION
Issue #338 
The condition to require a non-empty action list seemed rather arbitrary to me, so I'll leave this PR for your consideration.