### PR TITLE
Fix #361 - exception for 0-sized Terminal.

### DIFF
--- a/src/main/java/com/googlecode/lanterna/graphics/BasicTextImage.java
+++ b/src/main/java/com/googlecode/lanterna/graphics/BasicTextImage.java
@@ -171,7 +171,9 @@ public class BasicTextImage implements TextImage {
     
     @Override
     public void copyTo(TextImage destination) {
-        copyTo(destination, 0, buffer.length, 0, buffer[0].length, 0, 0);
+        if (buffer.length > 0) {
+            copyTo(destination, 0, buffer.length, 0, buffer[0].length, 0, 0);
+        }
     }
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/gui2/ComboBox.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/ComboBox.java
@@ -18,16 +18,19 @@
  */
 package com.googlecode.lanterna.gui2;
 
-import com.googlecode.lanterna.*;
-import com.googlecode.lanterna.graphics.Theme;
-import com.googlecode.lanterna.graphics.ThemeDefinition;
-import com.googlecode.lanterna.input.KeyStroke;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+
+import com.googlecode.lanterna.Symbols;
+import com.googlecode.lanterna.TerminalPosition;
+import com.googlecode.lanterna.TerminalSize;
+import com.googlecode.lanterna.TerminalTextUtils;
+import com.googlecode.lanterna.graphics.Theme;
+import com.googlecode.lanterna.graphics.ThemeDefinition;
+import com.googlecode.lanterna.input.KeyStroke;
 
 /**
  * This is a simple combo box implementation that allows the user to select one out of multiple items through a
@@ -374,7 +377,7 @@ public class ComboBox<V> extends AbstractInteractableComponent<ComboBox<V>> {
     }
 
     /**
-     * Returns the index of the currently selected item
+     * Returns the index of the currently selected item or -1 for no selection
      * @return Index of the currently selected item
      */
     public int getSelectedIndex() {
@@ -384,12 +387,12 @@ public class ComboBox<V> extends AbstractInteractableComponent<ComboBox<V>> {
     /**
      * Returns the item at the selected index, this is the same as calling:
      * <pre>
-     *     comboBox.getItem(comboBox.getSelectedIndex());
+     *     getSelectedIndex() > -1 ? getItem(getSelectedIndex()) : null
      * </pre>
      * @return The item at the selected index
      */
     public synchronized V getSelectedItem() {
-        return getItem(getSelectedIndex());
+        return getSelectedIndex() > -1 ? getItem(getSelectedIndex()) : null;
     }
 
     /**

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialog.java
@@ -34,15 +34,6 @@ public class ActionListDialog extends DialogWindow {
             String description,
             TerminalSize actionListPreferredSize,
             boolean canCancel,
-            List<Runnable> actions) {
-        this(title, description, actionListPreferredSize, canCancel, true, actions);
-    }
-
-    ActionListDialog(
-            String title,
-            String description,
-            TerminalSize actionListPreferredSize,
-            boolean canCancel,
             final boolean closeAutomatically,
             List<Runnable> actions) {
 

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialog.java
@@ -34,6 +34,7 @@ public class ActionListDialog extends DialogWindow {
             String description,
             TerminalSize actionListPreferredSize,
             boolean canCancel,
+	    final boolean closeAutomatically,
             List<Runnable> actions) {
 
         super(title);
@@ -47,7 +48,9 @@ public class ActionListDialog extends DialogWindow {
                 @Override
                 public void run() {
                     action.run();
-                    close();
+		    if(closeAutomatically) {
+			close();
+		    }
                 }
             });
         }

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialog.java
@@ -34,6 +34,15 @@ public class ActionListDialog extends DialogWindow {
             String description,
             TerminalSize actionListPreferredSize,
             boolean canCancel,
+            List<Runnable> actions) {
+        this(title, description, actionListPreferredSize, canCancel, true, actions);
+    }
+
+    ActionListDialog(
+            String title,
+            String description,
+            TerminalSize actionListPreferredSize,
+            boolean canCancel,
             final boolean closeAutomatically,
             List<Runnable> actions) {
 

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialog.java
@@ -34,7 +34,7 @@ public class ActionListDialog extends DialogWindow {
             String description,
             TerminalSize actionListPreferredSize,
             boolean canCancel,
-	    final boolean closeAutomatically,
+            final boolean closeAutomatically,
             List<Runnable> actions) {
 
         super(title);
@@ -48,9 +48,9 @@ public class ActionListDialog extends DialogWindow {
                 @Override
                 public void run() {
                     action.run();
-		    if(closeAutomatically) {
-			close();
-		    }
+                    if(closeAutomatically) {
+                        close();
+                    }
                 }
             });
         }

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialogBuilder.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialogBuilder.java
@@ -34,6 +34,7 @@ public class ActionListDialogBuilder extends AbstractDialogBuilder<ActionListDia
     private final List<Runnable> actions;
     private TerminalSize listBoxSize;
     private boolean canCancel;
+    private boolean closeAutomatically;
 
     /**
      * Default constructor
@@ -42,6 +43,7 @@ public class ActionListDialogBuilder extends AbstractDialogBuilder<ActionListDia
         super("ActionListDialogBuilder");
         this.listBoxSize = null;
         this.canCancel = true;
+	this.closeAutomatically = true;
         this.actions = new ArrayList<Runnable>();
     }
 
@@ -57,6 +59,7 @@ public class ActionListDialogBuilder extends AbstractDialogBuilder<ActionListDia
                 description,
                 listBoxSize,
                 canCancel,
+		closeAutomatically,
                 actions);
     }
 
@@ -148,5 +151,15 @@ public class ActionListDialogBuilder extends AbstractDialogBuilder<ActionListDia
      */
     public List<Runnable> getActions() {
         return new ArrayList<Runnable>(actions);
+    }
+
+    /**
+     * Sets if clicking on an action automatically closes the dialog after the action is finished (default: {@code true})
+     * @param closeAutomatically if {@code true} dialog will be automatically closed after choosing and finish any of the action
+     * @return Itself
+     */
+    public ActionListDialogBuilder setCloseAutomaticallyOnAction(boolean closeAutomatically) {
+	this.closeAutomatically = closeAutomatically;
+	return this;
     }
 }

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialogBuilder.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialogBuilder.java
@@ -43,7 +43,7 @@ public class ActionListDialogBuilder extends AbstractDialogBuilder<ActionListDia
         super("ActionListDialogBuilder");
         this.listBoxSize = null;
         this.canCancel = true;
-	this.closeAutomatically = true;
+        this.closeAutomatically = true;
         this.actions = new ArrayList<Runnable>();
     }
 
@@ -59,7 +59,7 @@ public class ActionListDialogBuilder extends AbstractDialogBuilder<ActionListDia
                 description,
                 listBoxSize,
                 canCancel,
-		closeAutomatically,
+                closeAutomatically,
                 actions);
     }
 
@@ -159,7 +159,7 @@ public class ActionListDialogBuilder extends AbstractDialogBuilder<ActionListDia
      * @return Itself
      */
     public ActionListDialogBuilder setCloseAutomaticallyOnAction(boolean closeAutomatically) {
-	this.closeAutomatically = closeAutomatically;
-	return this;
+        this.closeAutomatically = closeAutomatically;
+        return this;
     }
 }

--- a/src/test/java/com/googlecode/lanterna/issue/Issue361.java
+++ b/src/test/java/com/googlecode/lanterna/issue/Issue361.java
@@ -1,0 +1,32 @@
+/*
+ * Author Andrey Zelyaev(zella), slightly modified by Andreas(avl42)
+ */
+package com.googlecode.lanterna.issue;
+
+import com.googlecode.lanterna.gui2.*;
+import com.googlecode.lanterna.screen.*;
+import com.googlecode.lanterna.terminal.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class Issue361 {
+
+    public static void main(String[] args) throws Exception {
+
+        Terminal terminal = new DefaultTerminalFactory().createTerminal();
+        Screen screen = new TerminalScreen(terminal);
+        screen.startScreen();
+
+        BasicWindow window1 = new BasicWindow();
+        window1.setHints(Arrays.asList(Window.Hint.CENTERED));
+
+        BasicWindow window2 = new BasicWindow();
+        window2.setHints(Collections.<Window.Hint>emptyList());
+
+        // Create gui and start gui
+        MultiWindowTextGUI gui = new MultiWindowTextGUI(screen);
+        gui.addWindow(window2);
+        gui.addWindowAndWait(window1);
+    }
+}

--- a/src/test/java/com/googlecode/lanterna/issue/Issue361.java
+++ b/src/test/java/com/googlecode/lanterna/issue/Issue361.java
@@ -8,7 +8,6 @@ import com.googlecode.lanterna.screen.*;
 import com.googlecode.lanterna.terminal.*;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 public class Issue361 {
 
@@ -22,7 +21,7 @@ public class Issue361 {
         window1.setHints(Arrays.asList(Window.Hint.CENTERED));
 
         BasicWindow window2 = new BasicWindow();
-        window2.setHints(Collections.<Window.Hint>emptyList());
+        window2.setHints(Arrays.<Window.Hint>asList());
 
         // Create gui and start gui
         MultiWindowTextGUI gui = new MultiWindowTextGUI(screen);


### PR DESCRIPTION
I was always blind to that, because I thought the multi-args copyTo deals with all the "0"-cases, but it was the convenience wrapper itself that threw this exception.  Finally it's fixed.