### PR TITLE
allow empty action list in ActionListDialog

### DIFF
--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/ActionListDialog.java
@@ -38,9 +38,6 @@ public class ActionListDialog extends DialogWindow {
             List<Runnable> actions) {
 
         super(title);
-        if(actions.isEmpty()) {
-            throw new IllegalStateException("ActionListDialog needs at least one item");
-        }
 
         ActionListBox listBox = new ActionListBox(actionListPreferredSize);
         for(final Runnable action: actions) {


### PR DESCRIPTION
This is @asoltysik's PR #339 rebased to release/3.0

> Issue #338
> The condition to require a non-empty action list seemed rather arbitrary to me, so I'll leave this PR for your consideration.