### PR TITLE
Fix AbstractComposite.nextFocus for disabled components

### DIFF
--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractComposite.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractComposite.java
@@ -114,7 +114,10 @@ public abstract class AbstractComposite<T extends Container> extends AbstractCom
     @Override
     public Interactable nextFocus(Interactable fromThis) {
         if(fromThis == null && getComponent() instanceof Interactable) {
-            return (Interactable)getComponent();
+            Interactable interactable = (Interactable) getComponent();
+            if(interactable.isEnabled()) {
+                return interactable;
+            }
         }
         else if(getComponent() instanceof Container) {
             return ((Container)getComponent()).nextFocus(fromThis);
@@ -125,7 +128,10 @@ public abstract class AbstractComposite<T extends Container> extends AbstractCom
     @Override
     public Interactable previousFocus(Interactable fromThis) {
         if(fromThis == null && getComponent() instanceof Interactable) {
-            return (Interactable)getComponent();
+            Interactable interactable = (Interactable) getComponent();
+            if(interactable.isEnabled()) {
+                return interactable;
+            }
         }
         else if(getComponent() instanceof Container) {
             return ((Container)getComponent()).previousFocus(fromThis);

--- a/src/test/java/com/googlecode/lanterna/issue/Issue374.java
+++ b/src/test/java/com/googlecode/lanterna/issue/Issue374.java
@@ -1,0 +1,49 @@
+package com.googlecode.lanterna.issue;
+
+import com.googlecode.lanterna.gui2.*;
+import com.googlecode.lanterna.screen.Screen;
+import com.googlecode.lanterna.screen.TerminalScreen;
+import com.googlecode.lanterna.terminal.DefaultTerminalFactory;
+import com.googlecode.lanterna.terminal.Terminal;
+
+import java.util.Collections;
+
+public class Issue374 {
+
+    public static void main(String[] args) throws Exception {
+        Terminal terminal = new DefaultTerminalFactory().createTerminal();
+        Screen screen = new TerminalScreen(terminal);
+        screen.startScreen();
+
+        final BasicWindow window = new BasicWindow("FocusTraversalTest");
+        window.setHints(Collections.singletonList(Window.Hint.FULL_SCREEN));
+        MultiWindowTextGUI gui = new MultiWindowTextGUI(screen);
+
+        Panel mainPanel = new Panel(new LinearLayout());
+        window.setComponent(mainPanel);
+
+        Button disabledInBorder1 = new Button("disabledB1");
+        disabledInBorder1.setEnabled(false);
+        mainPanel.addComponent(disabledInBorder1.withBorder(Borders.singleLine("border")));
+
+        Button first = new Button("enabled");
+        mainPanel.addComponent(first);
+
+        Button disabled = new Button("disabled");
+        disabled.setEnabled(false);
+        mainPanel.addComponent(disabled);
+
+        Button disabledInBorder2 = new Button("disabledB2");
+        disabledInBorder2.setEnabled(false);
+        mainPanel.addComponent(disabledInBorder2.withBorder(Borders.singleLine("border")));
+
+        Button anotherFocusable = new Button("focusable");
+        mainPanel.addComponent(anotherFocusable);
+
+        mainPanel.addComponent(new Button("Button"));
+
+        first.takeFocus();
+        gui.addWindowAndWait(window);
+    }
+
+}


### PR DESCRIPTION
- composite should only offer its component for focus if given component is enabled
- a disabled component in a border breaks forcus traversal

fixes #374 