### PR TITLE
Fix #378

### DIFF
--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/FileDialog.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/FileDialog.java
@@ -164,7 +164,8 @@ public class FileDialog extends DialogWindow {
         @Override
         public void run() {
             if(!fileBox.getText().isEmpty()) {
-                selectedFile = new File(directory, fileBox.getText());
+                File file = new File(fileBox.getText());
+                selectedFile = file.isAbsolute() ? file : new File(directory, fileBox.getText());
                 close();
             }
             else {


### PR DESCRIPTION
When the path entered in fileBox is absolute, the directory from directoryListBox is ignored.