### PR TITLE
Overwrote Window.pack() to set disposed variable to false in SwingTerminalFrame.

### DIFF
--- a/src/main/java/com/googlecode/lanterna/terminal/swing/SwingTerminalFrame.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/swing/SwingTerminalFrame.java
@@ -158,6 +158,12 @@ public class SwingTerminalFrame extends JFrame implements IOSafeTerminal {
         super.dispose();
         disposed = true;
     }
+    
+    @Override
+    public void pack() {
+        super.pack();
+        disposed = false;
+    }
 
     @Override
     public void close() {


### PR DESCRIPTION
To set a frame to borderless mode, one must dispose, then undecorate, and finally repack the frame. However, disposing a  SwingTerminalFrame will set its disposed flag to true, which will cause its pollInput() method to permanently send EOF KeyStrokes. This would not be a problem, but when repacking the frame, the flag is not set to false. The end result is a frame that will not return keyboard input.

My change sets the dispose flag to false when pack() is called so that one can dispose and repack the SwingTerminalFrame an arbitrary number of times.