### PR TITLE
Modularize for JPMS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,13 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.sun.xml.ws</groupId>
+            <artifactId>jaxws-ri</artifactId>
+            <version>2.3.2</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -41,21 +48,57 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <source>1.6</source>
+                            <target>1.6</target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>java9</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <source>1.9</source>
+                            <target>1.9</target>
+                            <release>9</release>
+                            <multiReleaseOutput>true</multiReleaseOutput>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${basedir}/src/main/java9</compileSourceRoot>
+                            </compileSourceRoots>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <archive>
+                        <manifestEntries>
+                            <Multi-Release>true</Multi-Release>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>clirr-maven-plugin</artifactId>
-                <version>2.7</version>
+                <version>2.8</version>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.6.201602180812</version>
+                <version>0.8.4</version>
                 <executions>
                     <execution>
                         <id>default-prepare-agent</id>
@@ -75,7 +118,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>1.6.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -101,7 +144,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -114,7 +157,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.9.1</version>
+                        <version>3.1.1</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -128,7 +171,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -30,5 +30,5 @@ module com.googlecode.lanterna {
     exports com.googlecode.lanterna.terminal.swing;
     exports com.googlecode.lanterna.terminal.virtual;
 
-    requires java.desktop;
+    requires static java.desktop;
 }

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of lanterna (http://code.google.com/p/lanterna/).
+ *
+ * lanterna is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2010-2019 Martin Berglund
+ */
+module com.googlecode.lanterna {
+    exports com.googlecode.lanterna;
+    exports com.googlecode.lanterna.bundle;
+    exports com.googlecode.lanterna.graphics;
+    exports com.googlecode.lanterna.gui2;
+    exports com.googlecode.lanterna.gui2.dialogs;
+    exports com.googlecode.lanterna.gui2.table;
+    exports com.googlecode.lanterna.input;
+    exports com.googlecode.lanterna.screen;
+    exports com.googlecode.lanterna.terminal;
+    exports com.googlecode.lanterna.terminal.ansi;
+    exports com.googlecode.lanterna.terminal.swing;
+    exports com.googlecode.lanterna.terminal.virtual;
+
+    requires java.desktop;
+}


### PR DESCRIPTION
The PR has two commits and I recommend reviewing them individually:
- Packaging changes to create a multi-release jar file that works on Java 6+ and is a proper JPMS module (Java 9+). This bumps the minimum javac version to 9 but the resulting jar should work on Java 6 (untested).
- Remove the runtime dependency on the `java.desktop` module. This allows producing smaller runtime images if you don't need the terminal emulator parts nor the `TextColor.getColor()` method.

I tested it on Java 11 with a modularized version of the `OutputString` example both with and without the `java.desktop` module.

Is the package `com.googlecode.lanterna.bundle` meant to be used directly by the application/other libraries? If not, then its `exports` should be dropped.