### PR TITLE
Workaround for possible F3 vs CursorLocation ambiguity.

### DIFF
--- a/src/main/java/com/googlecode/lanterna/input/KeyStroke.java
+++ b/src/main/java/com/googlecode/lanterna/input/KeyStroke.java
@@ -50,7 +50,7 @@ public class KeyStroke {
      * @param keyType Type of the key pressed by this keystroke
      */
     public KeyStroke(KeyType keyType) {
-        this(keyType, false, false);
+        this(keyType, null, false, false, false);
     }
     
     /**
@@ -128,6 +128,13 @@ public class KeyStroke {
         this.ctrlDown = ctrlDown;
         this.altDown = altDown;
         this.eventTime = System.currentTimeMillis();
+    }
+
+    /**
+     * an F3-KeyStroke that is distinguishable from a CursorLocation report.
+     */
+    public static class RealF3 extends KeyStroke {
+        public RealF3() { super(KeyType.F3,false,false,false); }
     }
 
     /**

--- a/src/main/java/com/googlecode/lanterna/input/ScreenInfoCharacterPattern.java
+++ b/src/main/java/com/googlecode/lanterna/input/ScreenInfoCharacterPattern.java
@@ -49,6 +49,7 @@ public class ScreenInfoCharacterPattern extends EscapeSequenceCharacterPattern {
         switch (ks.getKeyType()) {
         case CursorLocation: return (ScreenInfoAction)ks;
         case F3: // reconstruct position from F3's modifiers.
+            if (ks instanceof KeyStroke.RealF3) { return null; }
             int col = 1 + (ks.isAltDown()  ? ALT  : 0)
                         + (ks.isCtrlDown() ? CTRL : 0)
                         + (ks.isShiftDown()? SHIFT: 0);


### PR DESCRIPTION
F3-key typically sends `^[OR` if unmodified, or `^[[1;<n>R` with `<n>` between 2 and 8, if shift'ed, ctrl'ed or alt'ed. A CursorLocation on the other hand always looks like `^[[<row>;<col>R`.

Therefore, shift'ed, alt'ed or ctrl'ed F3 can not be safely distinguished from a CursorLocation, but a bare F3 usually can.

This patch will make sure that a bare F3 key cannot get mistakenly taken for a CursorLocation.
