### PR TITLE
DefaultTerminalFactory Graal native-image support

### DIFF
--- a/src/main/java/com/googlecode/lanterna/terminal/DefaultTerminalFactory.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/DefaultTerminalFactory.java
@@ -124,7 +124,13 @@ public class DefaultTerminalFactory implements TerminalFactory {
         }
     }
 
-    @Override
+    /**
+     * Instantiates a Terminal according to the factory implementation with the exception that
+     * {@link DefaultTerminalFactory#preferTerminalEmulator} is always ignored. You may want to use this method when
+     * using tools that rely on AOT compilation such as Graal native-image to ensure AWT/Swing code paths are not hit.
+     * @return Terminal implementation
+     * @throws IOException If there was an I/O error with the underlying input/output system
+     */
     public Terminal createHeadlessTerminal() throws IOException {
         // if tty but have no tty, but do have a port, then go telnet:
         if( telnetPort > 0 && System.console() == null) {

--- a/src/main/java/com/googlecode/lanterna/terminal/DefaultTerminalFactory.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/DefaultTerminalFactory.java
@@ -110,16 +110,7 @@ public class DefaultTerminalFactory implements TerminalFactory {
         //       ("because we can" - unless "rather not")
         if (forceTextTerminal || isAwtHeadless() ||
                 (System.console() != null && !preferTerminalEmulator) ) {
-            // if tty but have no tty, but do have a port, then go telnet:
-            if( telnetPort > 0 && System.console() == null) {
-                return createTelnetTerminal();
-            }
-            if(isOperatingSystemWindows()) {
-                return createWindowsTerminal();
-            }
-            else {
-                return createUnixTerminal(outputStream, inputStream, charset);
-            }
+            return createHeadlessTerminal();
         }
         else {
             // while Lanterna's TerminalEmulator lacks mouse support:
@@ -131,6 +122,19 @@ public class DefaultTerminalFactory implements TerminalFactory {
                 return createTerminalEmulator();
             }
         }
+    }
+
+    @Override
+    public Terminal createHeadlessTerminal() throws IOException {
+        // if tty but have no tty, but do have a port, then go telnet:
+        if( telnetPort > 0 && System.console() == null) {
+            return createTelnetTerminal();
+        }
+        if(isOperatingSystemWindows()) {
+            return createWindowsTerminal();
+        }
+
+        return createUnixTerminal(outputStream, inputStream, charset);
     }
 
     /**

--- a/src/main/java/com/googlecode/lanterna/terminal/TerminalFactory.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/TerminalFactory.java
@@ -35,13 +35,4 @@ public interface TerminalFactory {
      * @throws IOException If there was an I/O error with the underlying input/output system
      */
     Terminal createTerminal() throws IOException;
-
-    /**
-     * Instantiates a Terminal according to the factory implementation with the exception that
-     * {@link DefaultTerminalFactory#preferTerminalEmulator} is always ignored. You may want to use this method when
-     * using tools that rely on AOT compilation such as Graal native-image to ensure AWT/Swing code paths are not hit.
-     * @return Terminal implementation
-     * @throws IOException If there was an I/O error with the underlying input/output system
-     */
-    Terminal createHeadlessTerminal() throws IOException;
 }

--- a/src/main/java/com/googlecode/lanterna/terminal/TerminalFactory.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/TerminalFactory.java
@@ -35,4 +35,13 @@ public interface TerminalFactory {
      * @throws IOException If there was an I/O error with the underlying input/output system
      */
     Terminal createTerminal() throws IOException;
+
+    /**
+     * Instantiates a Terminal according to the factory implementation with the exception that
+     * {@link DefaultTerminalFactory#preferTerminalEmulator} is always ignored. You may want to use this method when
+     * using tools that rely on AOT compilation such as Graal native-image to ensure AWT/Swing code paths are not hit.
+     * @return Terminal implementation
+     * @throws IOException If there was an I/O error with the underlying input/output system
+     */
+    Terminal createHeadlessTerminal() throws IOException;
 }


### PR DESCRIPTION
Resolves #440

I was able to workaround this without needing to do any module splitting. The issue is that the runtime checks in `TerminalFactory.createTerminal` isn't enough to tell Graal that AWT/Swing isn't going to be needed. I created a `createHeadlessTerminal` method which can be verified AOT that the emulators aren't going to be used. Using `createHeadlessTerminal` I'm able to use lanterna + native-image without any issues.

I'm not sure how you feel about this solution. It's simple, but maybe adding a new method to TerminalFactory isn't ideal? But I don't see many other alternatives.