### PR TITLE
Mouse support, Issue #452

### DIFF
--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractBasePane.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractBasePane.java
@@ -18,17 +18,18 @@
  */
 package com.googlecode.lanterna.gui2;
 
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import com.googlecode.lanterna.TerminalPosition;
 import com.googlecode.lanterna.TerminalSize;
 import com.googlecode.lanterna.graphics.Theme;
+import com.googlecode.lanterna.gui2.Interactable.Result;
 import com.googlecode.lanterna.gui2.menu.MenuBar;
 import com.googlecode.lanterna.input.KeyStroke;
 import com.googlecode.lanterna.input.KeyType;
 import com.googlecode.lanterna.input.MouseAction;
-
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This abstract implementation of {@code BasePane} has the common code shared by all different concrete
@@ -114,22 +115,15 @@ public abstract class AbstractBasePane<T extends BasePane> implements BasePane {
     private boolean doHandleInput(KeyStroke key) {
         boolean result = false;
         if(key.getKeyType() == KeyType.MouseEvent) {
-            MouseAction mouseAction = (MouseAction)key;
-            TerminalPosition localCoordinates = fromGlobal(mouseAction.getPosition());
-            if (localCoordinates != null) {
-                Interactable interactable = interactableLookupMap.getInteractableAt(localCoordinates);
-                if(interactable != null) {
-                    interactable.handleInput(key);
-                }
-            }
+           return handleMouseInput((MouseAction) key);
         }
-        else if(focusedInteractable == null) {
+        Interactable.FocusChangeDirection direction = Interactable.FocusChangeDirection.TELEPORT; // Default
+        Interactable nextFocus = null;
+        if(focusedInteractable == null) {
             // If nothing is focused and the user presses certain navigation keys, try to find if there is an
             // Interactable component we can move focus to.
             MenuBar menuBar = getMenuBar();
             Component baseComponent = getComponent();
-            Interactable.FocusChangeDirection direction = Interactable.FocusChangeDirection.TELEPORT;
-            Interactable nextFocus = null;
             switch (key.getKeyType()) {
                 case Tab:
                 case ArrowRight:
@@ -166,10 +160,7 @@ public abstract class AbstractBasePane<T extends BasePane> implements BasePane {
                 setFocusedInteractable(nextFocus, direction);
                 result = true;
             }
-        }
-        else {
-            Interactable next = null;
-            Interactable.FocusChangeDirection direction = Interactable.FocusChangeDirection.TELEPORT; //Default
+        } else {
             Interactable.Result handleResult = focusedInteractable.handleInput(key);
             if(!enableDirectionBasedMovements) {
                 if(handleResult == Interactable.Result.MOVE_FOCUS_DOWN || handleResult == Interactable.Result.MOVE_FOCUS_RIGHT) {
@@ -196,51 +187,63 @@ public abstract class AbstractBasePane<T extends BasePane> implements BasePane {
                     result = false;
                     break;
                 case MOVE_FOCUS_NEXT:
-                    next = contentHolder.nextFocus(focusedInteractable);
-                    if(next == null) {
-                        next = contentHolder.nextFocus(null);
+                    nextFocus = contentHolder.nextFocus(focusedInteractable);
+                    if(nextFocus == null) {
+                        nextFocus = contentHolder.nextFocus(null);
                     }
                     direction = Interactable.FocusChangeDirection.NEXT;
                     break;
                 case MOVE_FOCUS_PREVIOUS:
-                    next = contentHolder.previousFocus(focusedInteractable);
-                    if(next == null) {
-                        next = contentHolder.previousFocus(null);
+                    nextFocus = contentHolder.previousFocus(focusedInteractable);
+                    if(nextFocus == null) {
+                        nextFocus = contentHolder.previousFocus(null);
                     }
                     direction = Interactable.FocusChangeDirection.PREVIOUS;
                     break;
                 case MOVE_FOCUS_DOWN:
-                    next = interactableLookupMap.findNextDown(focusedInteractable);
+                    nextFocus = interactableLookupMap.findNextDown(focusedInteractable);
                     direction = Interactable.FocusChangeDirection.DOWN;
-                    if(next == null && !strictFocusChange) {
-                        next = contentHolder.nextFocus(focusedInteractable);
+                    if(nextFocus == null && !strictFocusChange) {
+                        nextFocus = contentHolder.nextFocus(focusedInteractable);
                         direction = Interactable.FocusChangeDirection.NEXT;
                     }
                     break;
                 case MOVE_FOCUS_LEFT:
-                    next = interactableLookupMap.findNextLeft(focusedInteractable);
+                    nextFocus = interactableLookupMap.findNextLeft(focusedInteractable);
                     direction = Interactable.FocusChangeDirection.LEFT;
                     break;
                 case MOVE_FOCUS_RIGHT:
-                    next = interactableLookupMap.findNextRight(focusedInteractable);
+                    nextFocus = interactableLookupMap.findNextRight(focusedInteractable);
                     direction = Interactable.FocusChangeDirection.RIGHT;
                     break;
                 case MOVE_FOCUS_UP:
-                    next = interactableLookupMap.findNextUp(focusedInteractable);
+                    nextFocus = interactableLookupMap.findNextUp(focusedInteractable);
                     direction = Interactable.FocusChangeDirection.UP;
-                    if(next == null && !strictFocusChange) {
-                        next = contentHolder.previousFocus(focusedInteractable);
+                    if(nextFocus == null && !strictFocusChange) {
+                        nextFocus = contentHolder.previousFocus(focusedInteractable);
                         direction = Interactable.FocusChangeDirection.PREVIOUS;
                     }
                     break;
             }
-            if(next != null) {
-                setFocusedInteractable(next, direction);
-                result = true;
-            }
+		}
+        if(nextFocus != null) {
+            setFocusedInteractable(nextFocus, direction);
+            result = true;
         }
         return result;
     }
+    
+    private boolean handleMouseInput(MouseAction mouseAction) {
+        TerminalPosition localCoordinates = fromGlobal(mouseAction.getPosition());
+        if (localCoordinates == null) {
+           return false;
+        }
+        Interactable interactable = interactableLookupMap.getInteractableAt(localCoordinates);
+        if (interactable == null) {
+           return false;
+        }
+        return interactable.handleInput(mouseAction) == Result.HANDLED;
+     }
 
     @Override
     public Component getComponent() {
@@ -458,10 +461,6 @@ public abstract class AbstractBasePane<T extends BasePane> implements BasePane {
 
         @Override
         public TerminalPosition toBasePane(TerminalPosition position) {
-            if (!(menuBar instanceof EmptyMenuBar)) {
-                int menuBarHeight = menuBar.getPreferredSize().getRows();
-                position = position.withRelativeRow(menuBarHeight);
-            }
             return position;
         }
 
@@ -483,6 +482,11 @@ public abstract class AbstractBasePane<T extends BasePane> implements BasePane {
 
         @Override
         public synchronized void onRemoved(Container container) {
+        }
+        
+        @Override
+        public boolean isEmptyMenuBar() {
+        	return true;
         }
     }
 }

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractComponent.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractComponent.java
@@ -205,6 +205,11 @@ public abstract class AbstractComponent<T extends Component> implements Componen
         return position;
     }
     
+	@Override
+	public TerminalPosition getGlobalPosition() {
+		return toGlobal(TerminalPosition.TOP_LEFT_CORNER);
+	}
+    
     @Override
     public boolean isInvalid() {
         return invalid;

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractComposite.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractComposite.java
@@ -18,12 +18,13 @@
  */
 package com.googlecode.lanterna.gui2;
 
-import com.googlecode.lanterna.TerminalPosition;
-import com.googlecode.lanterna.input.KeyStroke;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+
+import com.googlecode.lanterna.TerminalPosition;
+import com.googlecode.lanterna.gui2.menu.MenuBar;
+import com.googlecode.lanterna.input.KeyStroke;
 
 /**
  * This abstract implementation contains common code for the different {@code Composite} implementations. A
@@ -53,12 +54,17 @@ public abstract class AbstractComposite<T extends Container> extends AbstractCom
         if(oldComponent != null) {
             removeComponent(oldComponent);
         }
-        if(component != null) {
-            this.component = component;
-            component.onAdded(this);
-            component.setPosition(TerminalPosition.TOP_LEFT_CORNER);
-            invalidate();
-        }
+		if (component != null) {
+			this.component = component;
+			component.onAdded(this);
+			MenuBar menuBar = getBasePane().getMenuBar();
+			if (menuBar == null || menuBar.isEmptyMenuBar()) {
+				component.setPosition(TerminalPosition.TOP_LEFT_CORNER);
+			} else {
+				component.setPosition(TerminalPosition.TOP_LEFT_CORNER.withRelativeRow(1));
+			}
+			invalidate();
+		}
     }
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractListBox.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractListBox.java
@@ -18,14 +18,15 @@
  */
 package com.googlecode.lanterna.gui2;
 
-import com.googlecode.lanterna.TerminalTextUtils;
-import com.googlecode.lanterna.TerminalPosition;
-import com.googlecode.lanterna.TerminalSize;
-import com.googlecode.lanterna.graphics.ThemeDefinition;
-import com.googlecode.lanterna.input.KeyStroke;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import com.googlecode.lanterna.TerminalPosition;
+import com.googlecode.lanterna.TerminalSize;
+import com.googlecode.lanterna.TerminalTextUtils;
+import com.googlecode.lanterna.graphics.ThemeDefinition;
+import com.googlecode.lanterna.input.KeyStroke;
+import com.googlecode.lanterna.input.MouseAction;
 
 /**
  * Base class for several list box implementations, this will handle things like list of items and the scrollbar.
@@ -152,7 +153,10 @@ public abstract class AbstractListBox<V, T extends AbstractListBox<V, T>> extend
                 	if(selectByCharacter(keyStroke.getCharacter())) {
                         return Result.HANDLED;
                 	}
-                    
+                	return Result.UNHANDLED;
+                case MouseEvent:
+                	selectedIndex = getIndexByMouseAction((MouseAction) keyStroke);
+                	return super.handleKeyStroke(keyStroke);
                 default:
             }
             return Result.UNHANDLED;
@@ -161,6 +165,16 @@ public abstract class AbstractListBox<V, T extends AbstractListBox<V, T>> extend
             invalidate();
         }
     }
+    
+	/**
+	 * By converting {@link TerminalPosition}s to
+	 * {@link #toGlobal(TerminalPosition)} gets index clicked on by mouse action.
+	 * 
+	 * @return index of a item that was clicked on with {@link MouseAction}
+	 */
+	protected int getIndexByMouseAction(MouseAction click) {
+		return click.getPosition().getRow() - getGlobalPosition().getRow();
+	}
 
     private boolean selectByCharacter(Character character) {
 		character = Character.toLowerCase(character);

--- a/src/main/java/com/googlecode/lanterna/gui2/ActionListBox.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/ActionListBox.java
@@ -22,6 +22,7 @@ import com.googlecode.lanterna.TerminalPosition;
 import com.googlecode.lanterna.TerminalSize;
 import com.googlecode.lanterna.input.KeyStroke;
 import com.googlecode.lanterna.input.KeyType;
+import com.googlecode.lanterna.input.MouseAction;
 
 /**
  * This class is a list box implementation that displays a number of items that has actions associated with them. You
@@ -90,16 +91,21 @@ public class ActionListBox extends AbstractListBox<Runnable, ActionListBox> {
         return null;
     }
 
-    @Override
-    public Result handleKeyStroke(KeyStroke keyStroke) {
-        Object selectedItem = getSelectedItem();
-        if(selectedItem != null &&
-                (keyStroke.getKeyType() == KeyType.Enter ||
-                (keyStroke.getKeyType() == KeyType.Character && keyStroke.getCharacter() == ' '))) {
-
-            ((Runnable)selectedItem).run();
-            return Result.HANDLED;
-        }
-        return super.handleKeyStroke(keyStroke);
-    }
+	@Override
+	public Result handleKeyStroke(KeyStroke keyStroke) {
+		Object selectedItem = getSelectedItem();
+		if (selectedItem != null && (keyStroke.getKeyType() == KeyType.Enter
+				|| (keyStroke.getKeyType() == KeyType.Character && keyStroke.getCharacter() == ' ')
+				|| keyStroke.getKeyType() == KeyType.MouseEvent) && isFocused()) {
+			if (keyStroke.getKeyType() == KeyType.MouseEvent) {
+				int newIndex = getIndexByMouseAction((MouseAction) keyStroke);
+				if (newIndex != getSelectedIndex()) {
+					return super.handleKeyStroke(keyStroke);
+				}
+			}
+			((Runnable) selectedItem).run();
+			return Result.HANDLED;
+		}
+		return super.handleKeyStroke(keyStroke);
+	}
 }

--- a/src/main/java/com/googlecode/lanterna/gui2/Button.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/Button.java
@@ -18,16 +18,16 @@
  */
 package com.googlecode.lanterna.gui2;
 
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
 import com.googlecode.lanterna.Symbols;
-import com.googlecode.lanterna.TerminalTextUtils;
 import com.googlecode.lanterna.TerminalPosition;
 import com.googlecode.lanterna.TerminalSize;
+import com.googlecode.lanterna.TerminalTextUtils;
 import com.googlecode.lanterna.graphics.ThemeDefinition;
 import com.googlecode.lanterna.input.KeyStroke;
 import com.googlecode.lanterna.input.KeyType;
-
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Simple labeled button that the user can trigger by pressing the Enter or the Spacebar key on the keyboard when the
@@ -83,8 +83,9 @@ public class Button extends AbstractInteractableComponent<Button> {
 
     @Override
     public synchronized Result handleKeyStroke(KeyStroke keyStroke) {
-        if(keyStroke.getKeyType() == KeyType.Enter ||
-                (keyStroke.getKeyType() == KeyType.Character && keyStroke.getCharacter() == ' ')) {
+		if ((keyStroke.getKeyType() == KeyType.Enter
+				|| (keyStroke.getKeyType() == KeyType.Character && keyStroke.getCharacter() == ' ')
+				|| keyStroke.getKeyType() == KeyType.MouseEvent) && isFocused()) {
             triggerActions();
             return Result.HANDLED;
         }

--- a/src/main/java/com/googlecode/lanterna/gui2/CheckBox.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/CheckBox.java
@@ -18,15 +18,15 @@
  */
 package com.googlecode.lanterna.gui2;
 
-import com.googlecode.lanterna.TerminalTextUtils;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
 import com.googlecode.lanterna.TerminalPosition;
 import com.googlecode.lanterna.TerminalSize;
+import com.googlecode.lanterna.TerminalTextUtils;
 import com.googlecode.lanterna.graphics.ThemeDefinition;
 import com.googlecode.lanterna.input.KeyStroke;
 import com.googlecode.lanterna.input.KeyType;
-
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * The checkbox component looks like a regular checkbox that you can find in modern graphics user interfaces, a label
@@ -101,8 +101,9 @@ public class CheckBox extends AbstractInteractableComponent<CheckBox> {
 
     @Override
     public Result handleKeyStroke(KeyStroke keyStroke) {
-        if((keyStroke.getKeyType() == KeyType.Character && keyStroke.getCharacter() == ' ') ||
-                keyStroke.getKeyType() == KeyType.Enter) {
+		if (((keyStroke.getKeyType() == KeyType.Character && keyStroke.getCharacter() == ' ')
+				|| keyStroke.getKeyType() == KeyType.Enter || keyStroke.getKeyType() == KeyType.MouseEvent)
+				&& isFocused()) {
             setChecked(!isChecked());
             return Result.HANDLED;
         }

--- a/src/main/java/com/googlecode/lanterna/gui2/ComboBox.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/ComboBox.java
@@ -186,7 +186,7 @@ public class ComboBox<V> extends AbstractInteractableComponent<ComboBox<V>> {
         if(index == -1) {
             return this;
         }
-        return remoteItem(index);
+        return removeItem(index);
     }
 
     /**
@@ -195,7 +195,7 @@ public class ComboBox<V> extends AbstractInteractableComponent<ComboBox<V>> {
      * @return Itself
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public synchronized ComboBox<V> remoteItem(int index) {
+    public synchronized ComboBox<V> removeItem(int index) {
         items.remove(index);
         if(index < selectedIndex) {
             setSelectedIndex(selectedIndex - 1);

--- a/src/main/java/com/googlecode/lanterna/gui2/Component.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/Component.java
@@ -35,6 +35,15 @@ public interface Component extends TextGUIElement {
      * @return Position of this component
      */
     TerminalPosition getPosition();
+    
+	/**
+	 * Returns the top-left corner of this component in global coordinates space
+	 * using {@link TerminalPosition#TOP_LEFT_CORNER} with
+	 * {@link #toGlobal(TerminalPosition)}
+	 * 
+	 * @return global position of this component
+	 */
+	TerminalPosition getGlobalPosition();
 
     /**
      * This method will be called by the layout manager when it has decided where the component is to be located. If you

--- a/src/main/java/com/googlecode/lanterna/gui2/RadioBoxList.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/RadioBoxList.java
@@ -18,14 +18,15 @@
  */
 package com.googlecode.lanterna.gui2;
 
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
 import com.googlecode.lanterna.TerminalSize;
 import com.googlecode.lanterna.graphics.ThemeDefinition;
 import com.googlecode.lanterna.graphics.ThemeStyle;
 import com.googlecode.lanterna.input.KeyStroke;
 import com.googlecode.lanterna.input.KeyType;
-
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+import com.googlecode.lanterna.input.MouseAction;
 
 /**
  * The list box will display a number of items, of which one and only one can be marked as selected.
@@ -77,15 +78,22 @@ public class RadioBoxList<V> extends AbstractListBox<V, RadioBoxList<V>> {
         return new RadioBoxListItemRenderer<>();
     }
 
-    @Override
-    public synchronized Result handleKeyStroke(KeyStroke keyStroke) {
-        if(keyStroke.getKeyType() == KeyType.Enter ||
-                (keyStroke.getKeyType() == KeyType.Character && keyStroke.getCharacter() == ' ')) {
-            setCheckedIndex( getSelectedIndex() );
-            return Result.HANDLED;
-        }
-        return super.handleKeyStroke(keyStroke);
-    }
+	@Override
+	public synchronized Result handleKeyStroke(KeyStroke keyStroke) {
+		if ((keyStroke.getKeyType() == KeyType.Enter
+				|| (keyStroke.getKeyType() == KeyType.Character && keyStroke.getCharacter() == ' ')
+				|| keyStroke.getKeyType() == KeyType.MouseEvent) && isFocused()) {
+			if (keyStroke.getKeyType() == KeyType.MouseEvent) {
+				int newIndex = getIndexByMouseAction((MouseAction) keyStroke);
+				if (newIndex != getSelectedIndex()) {
+					return super.handleKeyStroke(keyStroke);
+				}
+			}
+			setCheckedIndex(getSelectedIndex());
+			return Result.HANDLED;
+		}
+		return super.handleKeyStroke(keyStroke);
+	}
 
     @Override
     public synchronized V removeItem(int index) {

--- a/src/main/java/com/googlecode/lanterna/gui2/TextBox.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/TextBox.java
@@ -18,15 +18,16 @@
  */
 package com.googlecode.lanterna.gui2;
 
-import com.googlecode.lanterna.TerminalTextUtils;
-import com.googlecode.lanterna.TerminalPosition;
-import com.googlecode.lanterna.TerminalSize;
-import com.googlecode.lanterna.graphics.ThemeDefinition;
-import com.googlecode.lanterna.input.KeyStroke;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
+
+import com.googlecode.lanterna.TerminalPosition;
+import com.googlecode.lanterna.TerminalSize;
+import com.googlecode.lanterna.TerminalTextUtils;
+import com.googlecode.lanterna.graphics.ThemeDefinition;
+import com.googlecode.lanterna.input.KeyStroke;
+import com.googlecode.lanterna.input.MouseAction;
 
 /**
  * This component keeps a text content that is editable by the user. A TextBox can be single line or multiline and lets
@@ -624,6 +625,21 @@ public class TextBox extends AbstractInteractableComponent<TextBox> {
                     caretPosition = caretPosition.withColumn(lines.get(caretPosition.getRow()).length());
                 }
                 return Result.HANDLED;
+			case MouseEvent:
+				if (!isFocused()) {
+					break;
+				}
+				MouseAction mouseAction = (MouseAction) keyStroke;
+				int newCaretPositionColumn = mouseAction.getPosition().getColumn() - getGlobalPosition().getColumn();
+				int newCaretPositionRow = mouseAction.getPosition().getRow() - getGlobalPosition().getRow();
+				String newActiveLine = lines.get(newCaretPositionRow);
+				if (newCaretPositionColumn > newActiveLine.length()) {
+					caretPosition = caretPosition.with(new TerminalPosition(newActiveLine.length(), newCaretPositionRow));
+				} else {
+					caretPosition = caretPosition
+							.with(new TerminalPosition(newCaretPositionColumn, newCaretPositionRow));
+				}
+				return Result.HANDLED;
             default:
         }
         return super.handleKeyStroke(keyStroke);

--- a/src/main/java/com/googlecode/lanterna/gui2/menu/Menu.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/menu/Menu.java
@@ -20,16 +20,16 @@
  */
 package com.googlecode.lanterna.gui2.menu;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import com.googlecode.lanterna.gui2.MenuPopupWindow;
 import com.googlecode.lanterna.gui2.Window;
 import com.googlecode.lanterna.gui2.WindowBasedTextGUI;
 import com.googlecode.lanterna.gui2.WindowListenerAdapter;
 import com.googlecode.lanterna.input.KeyStroke;
 import com.googlecode.lanterna.input.KeyType;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Implementation of a drop-down menu contained in a {@link MenuBar} and also a sub-menu inside another {@link Menu}.
@@ -61,50 +61,51 @@ public class Menu extends MenuItem {
     @Override
     protected boolean onActivated() {
         boolean result = true;
-        if (!subItems.isEmpty()) {
-            final MenuPopupWindow popupMenu = new MenuPopupWindow(this);
-            final AtomicBoolean popupCancelled = new AtomicBoolean(false);
-            for (MenuItem menuItem: subItems) {
-                popupMenu.addMenuItem(menuItem);
-            }
-            if (getParent() instanceof MenuBar) {
-                final MenuBar menuBar = (MenuBar)getParent();
-                popupMenu.addWindowListener(new WindowListenerAdapter() {
-                    @Override
-                    public void onUnhandledInput(Window basePane, KeyStroke keyStroke, AtomicBoolean hasBeenHandled) {
-                        if (keyStroke.getKeyType() == KeyType.ArrowLeft) {
-                            int thisMenuIndex = menuBar.getChildrenList().indexOf(Menu.this);
-                            if (thisMenuIndex > 0) {
-                                popupMenu.close();
-                                Menu nextSelectedMenu = menuBar.getMenu(thisMenuIndex - 1);
-                                nextSelectedMenu.takeFocus();
-                                nextSelectedMenu.onActivated();
-                            }
-                        }
-                        else if (keyStroke.getKeyType() == KeyType.ArrowRight) {
-                            int thisMenuIndex = menuBar.getChildrenList().indexOf(Menu.this);
-                            if (thisMenuIndex >= 0 && thisMenuIndex < menuBar.getMenuCount() - 1) {
-                                popupMenu.close();
-                                Menu nextSelectedMenu = menuBar.getMenu(thisMenuIndex + 1);
-                                nextSelectedMenu.takeFocus();
-                                nextSelectedMenu.onActivated();
-                            }
-                        }
-                    }
-                });
-            }
-            popupMenu.addWindowListener(new WindowListenerAdapter() {
-                @Override
-                public void onUnhandledInput(Window basePane, KeyStroke keyStroke, AtomicBoolean hasBeenHandled) {
-                    if (keyStroke.getKeyType() == KeyType.Escape) {
-                        popupCancelled.set(true);
-                        popupMenu.close();
-                    }
-                }
-            });
-            ((WindowBasedTextGUI)getTextGUI()).addWindowAndWait(popupMenu);
-            result = !popupCancelled.get();
+        if (subItems.isEmpty()) {
+        	return result;
         }
+		final MenuPopupWindow popupMenu = new MenuPopupWindow(this);
+		final AtomicBoolean popupCancelled = new AtomicBoolean(false);
+		for (MenuItem menuItem : subItems) {
+			popupMenu.addMenuItem(menuItem);
+		}
+		if (getParent() instanceof MenuBar) {
+			final MenuBar menuBar = (MenuBar) getParent();
+			popupMenu.addWindowListener(new WindowListenerAdapter() {
+				@Override
+				public void onUnhandledInput(Window basePane, KeyStroke keyStroke, AtomicBoolean hasBeenHandled) {
+					if (keyStroke.getKeyType() == KeyType.ArrowLeft) {
+						int thisMenuIndex = menuBar.getChildrenList().indexOf(Menu.this);
+						if (thisMenuIndex > 0) {
+							popupMenu.close();
+							Menu nextSelectedMenu = menuBar.getMenu(thisMenuIndex - 1);
+							nextSelectedMenu.takeFocus();
+							nextSelectedMenu.onActivated();
+						}
+					} else if (keyStroke.getKeyType() == KeyType.ArrowRight) {
+						int thisMenuIndex = menuBar.getChildrenList().indexOf(Menu.this);
+						if (thisMenuIndex >= 0 && thisMenuIndex < menuBar.getMenuCount() - 1) {
+							popupMenu.close();
+							Menu nextSelectedMenu = menuBar.getMenu(thisMenuIndex + 1);
+							nextSelectedMenu.takeFocus();
+							nextSelectedMenu.onActivated();
+						}
+					}
+				}
+			});
+		}
+		popupMenu.addWindowListener(new WindowListenerAdapter() {
+			@Override
+			public void onUnhandledInput(Window basePane, KeyStroke keyStroke, AtomicBoolean hasBeenHandled) {
+				if (keyStroke.getKeyType() == KeyType.Escape) {
+					popupCancelled.set(true);
+					popupMenu.close();
+				}
+			}
+		});
+		((WindowBasedTextGUI) getTextGUI()).addWindowAndWait(popupMenu);
+		result = !popupCancelled.get();
+        
         return result;
     }
 }

--- a/src/main/java/com/googlecode/lanterna/gui2/menu/MenuBar.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/menu/MenuBar.java
@@ -20,16 +20,22 @@
  */
 package com.googlecode.lanterna.gui2.menu;
 
-import com.googlecode.lanterna.Symbols;
-import com.googlecode.lanterna.TerminalPosition;
-import com.googlecode.lanterna.TerminalSize;
-import com.googlecode.lanterna.gui2.*;
-import com.googlecode.lanterna.input.KeyStroke;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+
+import com.googlecode.lanterna.TerminalPosition;
+import com.googlecode.lanterna.TerminalSize;
+import com.googlecode.lanterna.gui2.AbstractComponent;
+import com.googlecode.lanterna.gui2.Component;
+import com.googlecode.lanterna.gui2.ComponentRenderer;
+import com.googlecode.lanterna.gui2.Container;
+import com.googlecode.lanterna.gui2.Interactable;
+import com.googlecode.lanterna.gui2.InteractableLookupMap;
+import com.googlecode.lanterna.gui2.TextGUIGraphics;
+import com.googlecode.lanterna.gui2.Window;
+import com.googlecode.lanterna.input.KeyStroke;
 
 /**
  * A menu bar offering drop-down menus. You can attach a menu bar to a {@link Window} by using the
@@ -162,6 +168,10 @@ public class MenuBar extends AbstractComponent<MenuBar> implements Container {
     public TerminalPosition toBasePane(TerminalPosition position) {
         // Assume the menu is always at the top of the content panel
         return position;
+    }
+    
+    public boolean isEmptyMenuBar() {
+    	return false;
     }
 
     /**

--- a/src/main/java/com/googlecode/lanterna/gui2/menu/MenuItem.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/menu/MenuItem.java
@@ -87,8 +87,8 @@ public class MenuItem extends AbstractInteractableComponent<MenuItem> {
     @Override
     protected Result handleKeyStroke(KeyStroke keyStroke) {
         Result result;
-        if (keyStroke.getKeyType() == KeyType.Enter) {
-            if (onActivated()) {
+		if ((keyStroke.getKeyType() == KeyType.Enter || keyStroke.getKeyType() == KeyType.MouseEvent) && isFocused()) {
+			if (onActivated()) {
                 BasePane basePane = getBasePane();
                 if (basePane instanceof Window && ((Window) basePane).getHints().contains(Window.Hint.MENU_POPUP)) {
                     ((Window) basePane).close();

--- a/src/main/java/com/googlecode/lanterna/gui2/table/Table.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/table/Table.java
@@ -18,10 +18,13 @@
  */
 package com.googlecode.lanterna.gui2.table;
 
-import com.googlecode.lanterna.gui2.*;
-import com.googlecode.lanterna.input.KeyStroke;
-
 import java.util.List;
+
+import com.googlecode.lanterna.TerminalPosition;
+import com.googlecode.lanterna.gui2.AbstractInteractableComponent;
+import com.googlecode.lanterna.input.KeyStroke;
+import com.googlecode.lanterna.input.KeyType;
+import com.googlecode.lanterna.input.MouseAction;
 
 /**
  * The table class is an interactable component that displays a grid of cells containing data along with a header of
@@ -413,11 +416,54 @@ public class Table<V> extends AbstractInteractableComponent<Table<V>> {
                     return Result.MOVE_FOCUS_NEXT;
                 }
                 break;
+            case MouseEvent:
+            	if (!isFocused()) {
+            		return super.handleKeyStroke(keyStroke);
+				}
+            	int clickedRow = getRowByMouseAction((MouseAction) keyStroke);
+            	int clickedColumn = getColumnByMouseAction((MouseAction) keyStroke);
+            	if (clickedRow == selectedRow && clickedColumn == selectedColumn) {
+            		return handleKeyStroke(new KeyStroke(KeyType.Enter));
+				}
+            	selectedRow = clickedRow;
+            	selectedColumn = clickedColumn;
+            	break;
             default:
                 return super.handleKeyStroke(keyStroke);
         }
         invalidate();
         return Result.HANDLED;
     }
+    
+	/**
+	 * By converting {@link TerminalPosition}s to
+	 * {@link #toGlobal(TerminalPosition)} gets row clicked on by mouse action.
+	 * 
+	 * @return row of a table that was clicked on with {@link MouseAction}
+	 */
+	protected int getRowByMouseAction(MouseAction click) {
+		return click.getPosition().getRow() - getGlobalPosition().getRow() - 1;
+	}
+	
+	/**
+	 * By converting {@link TerminalPosition}s to
+	 * {@link #toGlobal(TerminalPosition)} and by comparing widths of column
+	 * headers, gets column clicked on by mouse action.
+	 * 
+	 * @return row of a table that was clicked on with {@link MouseAction}
+	 */
+	protected int getColumnByMouseAction(MouseAction click) {
+		int column = 0;
+		int columnSize = getTableHeaderRenderer().getPreferredSize(this, getTableModel().getColumnLabel(column), column)
+				.getColumns();
+		int globalColumnClicked = click.getPosition().getColumn() - getGlobalPosition().getColumn();
+		while (globalColumnClicked - columnSize - 1 >= 0) {
+			globalColumnClicked -= columnSize;
+			column++;
+			columnSize = getTableHeaderRenderer().getPreferredSize(this, getTableModel().getColumnLabel(column), column)
+					.getColumns();
+		}
+		return column;
+	}
 
 }

--- a/src/test/java/com/googlecode/lanterna/issue/Issue452.java
+++ b/src/test/java/com/googlecode/lanterna/issue/Issue452.java
@@ -1,0 +1,188 @@
+/*
+ * This file is part of lanterna (https://github.com/mabe02/lanterna).
+ *
+ * lanterna is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2010-2020 Martin Berglund
+ */
+package com.googlecode.lanterna.issue;
+
+import java.io.IOException;
+
+import com.googlecode.lanterna.TerminalSize;
+import com.googlecode.lanterna.gui2.ActionListBox;
+import com.googlecode.lanterna.gui2.BasicWindow;
+import com.googlecode.lanterna.gui2.Button;
+import com.googlecode.lanterna.gui2.Button.Listener;
+import com.googlecode.lanterna.gui2.CheckBox;
+import com.googlecode.lanterna.gui2.GridLayout;
+import com.googlecode.lanterna.gui2.Interactable;
+import com.googlecode.lanterna.gui2.LayoutData;
+import com.googlecode.lanterna.gui2.MultiWindowTextGUI;
+import com.googlecode.lanterna.gui2.Panel;
+import com.googlecode.lanterna.gui2.RadioBoxList;
+import com.googlecode.lanterna.gui2.TextBox;
+import com.googlecode.lanterna.gui2.TextBox.Style;
+import com.googlecode.lanterna.gui2.Window;
+import com.googlecode.lanterna.gui2.WindowBasedTextGUI;
+import com.googlecode.lanterna.gui2.menu.Menu;
+import com.googlecode.lanterna.gui2.menu.MenuBar;
+import com.googlecode.lanterna.gui2.menu.MenuItem;
+import com.googlecode.lanterna.gui2.table.Table;
+import com.googlecode.lanterna.screen.Screen;
+import com.googlecode.lanterna.terminal.DefaultTerminalFactory;
+import com.googlecode.lanterna.terminal.MouseCaptureMode;
+
+/**
+ * <p>
+ * Serves as showcase for all {@link Interactable} components for manual testing
+ * during development of mouse support. Uses Telnet port 23000 as you need
+ * something different than swing terminal provided by IDE. After launching main
+ * method you can connect to it via terminal "telnet localhost 23000" (or
+ * something of that nature)
+ * <p>
+ * Automatic tests can be found in {@link Issue452Test}.
+ */
+public class Issue452 {
+
+	private static final int GRID_WIDTH = 100;
+	private static final LayoutData LAYOUT_NEW_ROW = GridLayout.createHorizontallyFilledLayoutData(GRID_WIDTH);
+	private static int buttonTriggeredCounter = 0;
+	private static TextBox actionListTextBox;
+	private static TextBox menuTextBox;
+	private static TextBox tableTextBox;
+	private static int tableTriggeredCounter = 0;
+
+	public static void main(String[] args) throws IOException {
+		try (Screen screen = new DefaultTerminalFactory().setTelnetPort(23000)
+				.setMouseCaptureMode(MouseCaptureMode.CLICK).setInitialTerminalSize(new TerminalSize(100, 100))
+				.createScreen()) {
+			screen.startScreen();
+			WindowBasedTextGUI gui = new MultiWindowTextGUI(screen);
+			Window window = new BasicWindow("Issue452");
+			Panel content = new Panel(new GridLayout(GRID_WIDTH));
+			GridLayout gridLayout = (GridLayout) content.getLayoutManager();
+			gridLayout.setVerticalSpacing(1);
+			addInteractableComponentsToContent(content);
+			addMenuBar(window);
+			window.setComponent(content);
+			gui.addWindowAndWait(window);
+		}
+	}
+
+	private static void addInteractableComponentsToContent(Panel content) {
+		// for menu bar so you know which menu you have triggered
+		menuTextBox = new TextBox("Try menu above");
+		content.addComponent(menuTextBox, LAYOUT_NEW_ROW);
+
+		// single line textbox
+		content.addComponent(new TextBox("Single line TextBox"), LAYOUT_NEW_ROW);
+
+		// multi line textbox
+		content.addComponent(new TextBox(
+				"First line of multi line TextBox" + System.lineSeparator() + "Second line of multi line TextBox",
+				Style.MULTI_LINE), LAYOUT_NEW_ROW);
+
+		// checkbox
+		content.addComponent(new CheckBox("CheckBox"), LAYOUT_NEW_ROW);
+
+		// button
+		TextBox textBoxButton = new TextBox("Click the button!");
+		Button button = new Button("Button");
+		button.addListener(new Listener() {
+			@Override
+			public void onTriggered(Button button) {
+				textBoxButton.setText("Button triggered " + Issue452.buttonTriggeredCounter++ + " times");
+			}
+		});
+		content.addComponent(button, GridLayout.createHorizontallyFilledLayoutData(1));
+		content.addComponent(textBoxButton, GridLayout.createHorizontallyFilledLayoutData(GRID_WIDTH - 1));
+
+		// action list box
+		actionListTextBox = new TextBox("Click on something in the action list!");
+		ActionListBox actionMenu = new ActionListBox();
+		actionMenu.addItem("First menu", new Runnable() {
+			@Override
+			public void run() {
+				actionListTextBox.setText("First menu clicked");
+			}
+		});
+		actionMenu.addItem("Second menu", new Runnable() {
+			@Override
+			public void run() {
+				actionListTextBox.setText("Second menu clicked");
+			}
+		});
+		actionMenu.addItem("Third menu", new Runnable() {
+			@Override
+			public void run() {
+				actionListTextBox.setText("Third menu clicked");
+			}
+		});
+		content.addComponent(actionListTextBox, LAYOUT_NEW_ROW);
+		content.addComponent(actionMenu, LAYOUT_NEW_ROW);
+
+		// radiobox list
+		RadioBoxList<String> list = new RadioBoxList<>();
+		list.addItem("RadioGaga");
+		list.addItem("RadioGogo");
+		list.addItem("RadioBlaBla");
+		content.addComponent(list, LAYOUT_NEW_ROW);
+
+		// Table
+		tableTextBox = new TextBox("Try table bellow");
+		Table<String> table = new Table<>("Column0000000", "Column111", "Column22222");
+		table.getTableModel().addRow("0", "0", "0");
+		table.getTableModel().addRow("1", "1", "1");
+		table.getTableModel().addRow("2", "2", "2");
+		table.setSelectAction(() -> {
+			tableTriggeredCounter++;
+			tableTextBox.setText("Table's action runned " + tableTriggeredCounter + " times");
+		});
+		table.setCellSelection(true);
+		content.addComponent(tableTextBox, LAYOUT_NEW_ROW);
+		content.addComponent(table, LAYOUT_NEW_ROW);
+	}
+
+	private static void addMenuBar(Window window) {
+		MenuBar menuBar = new MenuBar();
+		Menu menu = new Menu("Settings");
+		menu.add(new MenuItem("Menu1", new Runnable() {
+			@Override
+			public void run() {
+				menuTextBox.setText("Menu1 clicked");
+				menuTextBox.invalidate();
+			}
+		}));
+		menu.add(new MenuItem("Menu2", new Runnable() {
+
+			@Override
+			public void run() {
+				menuTextBox.setText("Menu2 clicked");
+				menuTextBox.invalidate();
+			}
+		}));
+		menu.add(new MenuItem("Menu3", new Runnable() {
+
+			@Override
+			public void run() {
+				menuTextBox.setText("Menu3 clicked");
+				menuTextBox.invalidate();
+			}
+		}));
+		menuBar.add(menu);
+		window.setMenuBar(menuBar);
+	}
+
+}

--- a/src/test/java/com/googlecode/lanterna/issue/Issue452Test.java
+++ b/src/test/java/com/googlecode/lanterna/issue/Issue452Test.java
@@ -1,0 +1,323 @@
+/*
+ * This file is part of lanterna (https://github.com/mabe02/lanterna).
+ *
+ * lanterna is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2010-2020 Martin Berglund
+ */
+package com.googlecode.lanterna.issue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.googlecode.lanterna.TerminalPosition;
+import com.googlecode.lanterna.gui2.ActionListBox;
+import com.googlecode.lanterna.gui2.BasicWindow;
+import com.googlecode.lanterna.gui2.Button;
+import com.googlecode.lanterna.gui2.CheckBox;
+import com.googlecode.lanterna.gui2.GridLayout;
+import com.googlecode.lanterna.gui2.Interactable;
+import com.googlecode.lanterna.gui2.LayoutData;
+import com.googlecode.lanterna.gui2.Panel;
+import com.googlecode.lanterna.gui2.RadioBoxList;
+import com.googlecode.lanterna.gui2.TextBox;
+import com.googlecode.lanterna.gui2.TextBox.Style;
+import com.googlecode.lanterna.gui2.Window;
+import com.googlecode.lanterna.gui2.table.Table;
+import com.googlecode.lanterna.input.KeyStroke;
+import com.googlecode.lanterna.input.KeyType;
+import com.googlecode.lanterna.input.MouseAction;
+import com.googlecode.lanterna.input.MouseActionType;
+import com.googlecode.lanterna.screen.TerminalScreen;
+
+/**
+ * Automatic tests for mouse support. These test do not actually lauch
+ * {@link TerminalScreen} as testing that is not the point. Point is to test how
+ * different {@link Interactable}s handle mouse clicks.
+ */
+public class Issue452Test {
+
+	private Panel content;
+	private Window window;
+	private static final int GRID_WIDTH = 100;
+	private static final LayoutData LAYOUT_NEW_ROW = GridLayout.createHorizontallyFilledLayoutData(GRID_WIDTH);
+
+	@Before
+	public void before() {
+		window = new BasicWindow("Issue452Test");
+		content = new Panel(new GridLayout(GRID_WIDTH));
+		GridLayout gridLayout = (GridLayout) content.getLayoutManager();
+		gridLayout.setVerticalSpacing(1);
+		window.setPosition(TerminalPosition.TOP_LEFT_CORNER);
+		window.setComponent(content);
+	}
+
+	@Test
+	public void testSingleLineTextBox() {
+		TextBox singleLine = new TextBox("123456789");
+		content.addComponent(singleLine, LAYOUT_NEW_ROW);
+		// Focus component
+		clickOn(singleLine);
+		assertTrue(singleLine.isFocused());
+		// Click at 3rd position
+		singleLine.handleInput(clickAt(3, 0));
+		singleLine.handleInput(new KeyStroke(KeyType.Backspace));
+		// 3rd position (3) should be deleted
+		assertEquals("12456789", singleLine.getText());
+	}
+
+	@Test
+	public void testMultuLineTextBox() {
+		TextBox multiLine = new TextBox("123456789" + System.lineSeparator() + "abcdefgh", Style.MULTI_LINE);
+		content.addComponent(multiLine, LAYOUT_NEW_ROW);
+		// Focus component
+		clickOn(multiLine);
+		assertTrue(multiLine.isFocused());
+		// Click at 3rd position 1st row
+		multiLine.handleInput(clickAt(3, 0));
+		multiLine.handleInput(new KeyStroke(KeyType.Backspace));
+		// 3rd position (3) should be deleted
+		assertEquals("12456789" + System.lineSeparator() + "abcdefgh", multiLine.getText());
+		// Click at 5th position 2nd row
+		multiLine.handleInput(clickAt(5, 1));
+		multiLine.handleInput(new KeyStroke(KeyType.Backspace));
+		// 5th position (e) should be deleted
+		assertEquals("12456789" + System.lineSeparator() + "abcdfgh", multiLine.getText());
+	}
+
+	@Test
+	public void testCheckBox() {
+		CheckBox checkBox = new CheckBox("Checkbox");
+		content.addComponent(checkBox, LAYOUT_NEW_ROW);
+		assertFalse(checkBox.isFocused());
+		assertFalse(checkBox.isChecked());
+		// First click should only focus the checkbox
+		clickOn(checkBox);
+		assertTrue(checkBox.isFocused());
+		assertFalse(checkBox.isChecked());
+		// Second click should change its value to TRUE
+		clickOn(checkBox);
+		assertTrue(checkBox.isFocused());
+		assertTrue(checkBox.isChecked());
+		// Third click should change its value back to FALSE
+		clickOn(checkBox);
+		assertTrue(checkBox.isFocused());
+		assertFalse(checkBox.isChecked());
+	}
+
+	@Test
+	public void testButton() {
+		Button button = new Button("Button", createRunnable("Button"));
+		content.addComponent(button, LAYOUT_NEW_ROW);
+		assertFalse(button.isFocused());
+		// First click should only focus the button
+		clickOn(button);
+		try {
+			clickOn(button);
+			fail();
+		} catch (RunnableExecuted e) {
+			assertEquals("Button", e.getName());
+		}
+	}
+
+	@Test
+	public void testActionListBox() {
+		ActionListBox menu = new ActionListBox();
+		menu.addItem(createRunnable("Menu1"));
+		menu.addItem(createRunnable("Menu2"));
+		menu.addItem(createRunnable("Menu3"));
+		menu.addItem(createRunnable("Menu4"));
+		content.addComponent(menu, LAYOUT_NEW_ROW);
+		clickOn(menu);
+		// First index is selected at the beginning so no need to focus it
+		assertEquals(0, menu.getSelectedIndex());
+		try {
+			menu.handleInput(clickAt(0, 0));
+			fail();
+		} catch (RunnableExecuted e) {
+			assertEquals("Menu1", e.getName());
+		}
+		// First click on second menu to focus
+		menu.handleInput(clickAt(0, 1));
+		assertEquals(1, menu.getSelectedIndex());
+		try {
+			menu.handleInput(clickAt(0, 1));
+			fail();
+		} catch (RunnableExecuted e) {
+			assertEquals("Menu2", e.getName());
+		}
+		// First click on third menu to focus
+		menu.handleInput(clickAt(0, 2));
+		assertEquals(2, menu.getSelectedIndex());
+		try {
+			menu.handleInput(clickAt(0, 2));
+			fail();
+		} catch (RunnableExecuted e) {
+			assertEquals("Menu3", e.getName());
+		}
+		// First click on forth menu to focus
+		menu.handleInput(clickAt(0, 3));
+		assertEquals(3, menu.getSelectedIndex());
+		try {
+			menu.handleInput(clickAt(0, 3));
+			fail();
+		} catch (RunnableExecuted e) {
+			assertEquals("Menu4", e.getName());
+		}
+	}
+
+	@Test
+	public void testRadioBoxList() {
+		RadioBoxList<String> list = new RadioBoxList<>();
+		list.addItem("RadioGaga");
+		list.addItem("RadioGogo");
+		list.addItem("RadioBlaBla");
+		content.addComponent(list, LAYOUT_NEW_ROW);
+		// At start, first radio is selected but nothing should be checked
+		assertEquals("RadioGaga", list.getSelectedItem());
+		assertEquals(null, list.getCheckedItem());
+
+		list.handleInput(clickAt(0, 1));
+		// second radio should be selected but still nothing should be checked
+		assertEquals("RadioGogo", list.getSelectedItem());
+		assertEquals(null, list.getCheckedItem());
+
+		list.handleInput(clickAt(0, 2));
+		// third radio should be selected but still nothing should be checked
+		assertEquals("RadioBlaBla", list.getSelectedItem());
+		assertEquals(null, list.getCheckedItem());
+
+		list.handleInput(clickAt(0, 2));
+		// second click on third radio so it should now be selected as well as checked
+		assertEquals("RadioBlaBla", list.getSelectedItem());
+		assertEquals("RadioBlaBla", list.getCheckedItem());
+
+		list.handleInput(clickAt(0, 0));
+		// first click on first radio so it should now be selected , but third radio
+		// still should be checked
+		assertEquals("RadioGaga", list.getSelectedItem());
+		assertEquals("RadioBlaBla", list.getCheckedItem());
+
+		list.handleInput(clickAt(0, 0));
+		// second click on first radio so it should now be selected as well as checked
+		assertEquals("RadioGaga", list.getSelectedItem());
+		assertEquals("RadioGaga", list.getCheckedItem());
+	}
+
+	@Test
+	public void testTable() {
+		Table<String> table = new Table<>("Column0000000", "Column111", "Column22222");
+		table.getTableModel().addRow("0", "0", "0");
+		table.getTableModel().addRow("1", "1", "1");
+		table.getTableModel().addRow("2", "2", "2");
+		table.setSelectAction(createRunnable("Table"));
+		table.setCellSelection(true);
+		content.addComponent(table, LAYOUT_NEW_ROW);
+
+		assertFalse(table.isFocused());
+		clickOn(table);
+		// after first click table should be focused and first column a first row should
+		// be selected
+		assertTrue(table.isFocused());
+		assertEquals(0, table.getSelectedColumn());
+		assertEquals(0, table.getSelectedRow());
+
+		// 0, 0 would get activated by first click so just to be able to run same method
+		// for all indices sets position to 1, 1
+		table.setSelectedColumn(1);
+		table.setSelectedRow(1);
+		for (int positionRow = 0; positionRow < table.getTableModel().getRowCount(); positionRow++) {
+			for (int positionColumn = 0; positionColumn < table.getTableModel().getColumnCount(); positionColumn++) {
+				assertTablePositionSelectedAndExecuted(table, positionRow, positionColumn);
+			}
+		}
+
+	}
+
+	/**
+	 * Every click will have +1 on row because first row is column headers, columns
+	 * will have + length of previous column header lenghts because they span
+	 * multiple columns
+	 */
+	private void assertTablePositionSelectedAndExecuted(Table<String> table, int positionRow, int positionColumn) {
+		int previousCollumnsWidth = 0;
+		for (int i = 0; i < positionColumn; i++) {
+			previousCollumnsWidth += table.getTableModel().getColumnLabel(i).length();
+		}
+		clickOnWithRelative(table, positionColumn + previousCollumnsWidth, positionRow + 1);
+		assertEquals(positionColumn, table.getSelectedColumn());
+		assertEquals(positionRow, table.getSelectedRow());
+		try {
+			clickOnWithRelative(table, positionColumn + previousCollumnsWidth, positionRow + 1);
+			fail();
+		} catch (RunnableExecuted e) {
+			assertEquals("Table", e.getName());
+			assertEquals(positionColumn, table.getSelectedColumn());
+			assertEquals(positionRow, table.getSelectedRow());
+		}
+	}
+
+	/**
+	 * Clicks at position
+	 */
+	private MouseAction clickAt(int column, int row) {
+		return new MouseAction(MouseActionType.CLICK_DOWN, 1, new TerminalPosition(column, row));
+	}
+
+	/**
+	 * Clicks at position of the {@link Interactable}
+	 */
+	private void clickOn(Interactable component) {
+		component.handleInput(clickAt(component.getPosition().getColumn(), component.getPosition().getRow()));
+	}
+
+	/**
+	 * Clicks at position of the {@link Interactable} with offset
+	 */
+	private void clickOnWithRelative(Interactable component, int column, int row) {
+		component.handleInput(
+				clickAt(component.getPosition().getColumn() + column, component.getPosition().getRow() + row));
+	}
+
+	private Runnable createRunnable(String name) {
+		return new Runnable() {
+			@Override
+			public void run() {
+				// propagate that this runnable was executed
+				throw new RunnableExecuted(name);
+			}
+		};
+	}
+
+	private class RunnableExecuted extends RuntimeException {
+
+		private static final long serialVersionUID = 1L;
+		private String name;
+
+		public RunnableExecuted(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+	}
+
+}


### PR DESCRIPTION
Mouse support for: Button, TextBox, CheckBox, ActionListBox, RadioListBox, Menu and Table and a bit of refactoring. 

I mostly edited handleKeyStroke methods of these components but when I came across MenuBar, Menu and MenuItem  I ran into a problem with how components were drawn if there was or was not Menu at the top. What I found out was that if there is a Menu bar, all components would be down by 1 row but their coordinates would stay the same, as if there was no Menu bar and that was messing up mouse clicks, obviously. So what I have done is: edited AbstactComposite#setComponent to take into account that +1 if there is MenuBar present and since EmptyMenuBar is an inner class I had to do a bit of an ugliness. With that I also removed what I believe was another hack in AbstractBasePane where there was something similar with EmptyMenuBar handling. 

I also added getGlobalPosition in Component interface for convenient access to global coordinates of top the left corner of the component.

One component that I was not able to make reactive to mouse is ComboBox because of that inner window which for some reason was not responsive to mouse clicks.

I tested everything on Linux Mint 19.1 inside standard terminal and telnet. I was not able to get it working in putty though. And obviously I don't know all uses of all components so it is possible it is not even working in some cases. 

I have a few more aesthetic modifications in mind, for example extract that same old "if (enter || mouse || character(' ') && isFocused)" in every handleKeyStroke; some "is" methods on KeyStroke like "isEnter" "isMouseClick" and so on, which would in my opinion make it more readable, but that is for future PR, first I want to get this one through.