### PR TITLE
Allow AbstractTerminal subclasses to manipulate resize listener behavior

### DIFF
--- a/src/main/java/com/googlecode/lanterna/terminal/AbstractTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/AbstractTerminal.java
@@ -33,8 +33,8 @@ import java.util.List;
  */
 public abstract class AbstractTerminal implements Terminal {
 
-    private final List<TerminalResizeListener> resizeListeners;
-    private TerminalSize lastKnownSize;
+    protected final List<TerminalResizeListener> resizeListeners;
+    protected TerminalSize lastKnownSize;
 
     protected AbstractTerminal() {
         this.resizeListeners = new ArrayList<>();


### PR DESCRIPTION
The use case motivating this change is that I'd like to force resize listeners to fire, even when the size didn't change, in order to trigger a full `Screen` refresh.