### PR TITLE
Fix for Issue #537

### DIFF
--- a/src/main/java/com/googlecode/lanterna/terminal/ansi/TelnetTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/ansi/TelnetTerminal.java
@@ -273,7 +273,12 @@ public class TelnetTerminal extends ANSITerminal {
 
             int oldTimeout = socket.getSoTimeout();
             if (!block) { socket.setSoTimeout(1); }
-            int readBytes = inputStream.read(workingBuffer, 0, maxFill);
+            int readBytes;
+            try {
+                readBytes = inputStream.read(workingBuffer, 0, maxFill);
+            } catch (java.net.SocketTimeoutException ste) {
+                readBytes = 0;
+            }
             if (!block) { socket.setSoTimeout(oldTimeout); }
 
             if (readBytes == -1) {


### PR DESCRIPTION
I apologize that this even happened in the first place... pah!  It's eclipse's fault, for apparently working despite the bug  ;-) 

Explanation:

When a timeout is set on a Socket, then by documentation the read(...) call throws an exception if it doesn't receive data in time.
eclipse instead just silently returned 0 bytes without throwing an exception, thus I forgot to add the necessary try-catch block.

For now I cannot try this change with eclipse, so I do hope that eclipse at least won't complain about the catch...