### PR TITLE
Disable thumb in SplitPanel

### DIFF
--- a/src/main/java/com/googlecode/lanterna/gui2/SplitPanel.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/SplitPanel.java
@@ -111,6 +111,7 @@ public class SplitPanel extends Panel {
                 return Result.HANDLED;
             }
         };
+        imageComponent.setEnabled(false);
         
         return imageComponent;
     }


### PR DESCRIPTION
Currently, the thumb in `SplitPanel` gets focus on Tab, but itself doesn't handle Tab key again to pass the focus forward. Same for reverse Tab. This effectively breaks the whole tabbing idea if any `SplitPanel` is present in the window.

To fix this, this change disables the thumb component.