### PR TITLE
Do not display blinking cursor when setCursorVisible(false) called

### DIFF
--- a/src/main/java/com/googlecode/lanterna/terminal/swing/GraphicalTerminalImplementation.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/swing/GraphicalTerminalImplementation.java
@@ -424,7 +424,7 @@ abstract class GraphicalTerminalImplementation implements IOSafeTerminal {
                     Color foregroundColor = deriveTrueForegroundColor(textCharacter, atCursorLocation);
                     Color backgroundColor = deriveTrueBackgroundColor(textCharacter, atCursorLocation);
                     //Always draw if the cursor isn't blinking
-                    boolean drawCursor = atCursorLocation && (!deviceConfiguration.isCursorBlinking() || blinkOn);    //If the cursor is blinking, only draw when blinkOn is true
+                    boolean drawCursor = atCursorLocation && cursorIsVisible && (!deviceConfiguration.isCursorBlinking() || blinkOn);    //If the cursor should be displayed and is blinking, only draw when blinkOn is true
 
                     // Visualize bell as all colors inverted
                     if(bellOn) {


### PR DESCRIPTION
In the Swing Terminal Emulator, a blinking cursor currently cannot be made invisible with setCursorVisible(false) - it's still there and blinking.


    /**
     * Steps to reproduce the blinking cursor bug
     */
    public static void main(String[] args) throws Exception {
        TerminalEmulatorDeviceConfiguration deviceConfiguration =
                TerminalEmulatorDeviceConfiguration.getDefault()
                        .withBlinkLengthInMilliSeconds(333)
                        .withCursorStyle(TerminalEmulatorDeviceConfiguration.CursorStyle.UNDER_BAR)
                        .withCursorBlinking(true);
        DefaultTerminalFactory factory = new DefaultTerminalFactory();
        factory.setTerminalEmulatorDeviceConfiguration(deviceConfiguration);
        factory.setInitialTerminalSize(new TerminalSize(80, 25));
        Terminal terminal = factory.createTerminal(); // creates a Swing terminal
        terminal.enterPrivateMode();

        terminal.setCursorPosition(2, 2);
        terminal.setCursorVisible(true);
        terminal.putString("Cursor is visible now at end of line (press any key to continue): ");
        terminal.flush();
        terminal.readInput();

        terminal.setCursorPosition(2, 3);
        terminal.setCursorVisible(false);
        terminal.putString("Cursor should be INVISIBLE now: "); // Bug: it is STILL VISIBLE with Lanterna 3.1.1
        terminal.flush();
        terminal.readInput();

        terminal.exitPrivateMode();
        terminal.close();
    }