### PR TITLE
Fix: pass correct target focus to previous focus

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.0

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractBasePane.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractBasePane.java
@@ -315,7 +315,7 @@ public abstract class AbstractBasePane<T extends BasePane> implements BasePane {
             return;
         }
         if(focusedInteractable != null) {
-            focusedInteractable.onLeaveFocus(direction, focusedInteractable);
+            focusedInteractable.onLeaveFocus(direction, toFocus);
         }
         Interactable previous = focusedInteractable;
         focusedInteractable = toFocus;


### PR DESCRIPTION
Hi,

When using this library, I noticed that when overriding `afterLeaveFocus(direction: Interactable.FocusChangeDirection, nextInFocus: Interactable)`, the `nextInFocus` variable was actually set to the current Interactable and not the target one.

This patch fixes that.

Thank you
