### PR TITLE
Fix Jitpack compilation

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk9


### PR DESCRIPTION
Hi,

This small configuration file makes it such that Jitpack is able to compile the project, making snapshots easily available.

Currently it fails because javac from JDK 8 encounters an unrecognised argument:

https://jitpack.io/com/github/mabe02/lanterna/54f5b4ca6b/build.log

This is fixed when using JDK 9:

https://jitpack.io/com/github/freyacodes/lanterna/2e63dd24b2/build.log

