### PR TITLE
Remove duplicated argument to String.format

### DIFF
--- a/src/main/java/com/googlecode/lanterna/terminal/win32/WinDef.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/win32/WinDef.java
@@ -107,7 +107,7 @@ public interface WinDef extends com.sun.jna.platform.win32.WinDef {
 
 		@Override
 		public String toString() {
-			return String.format("KEY_EVENT_RECORD(%s,%s,%s,%s,%s,%s)", bKeyDown, wRepeatCount, wVirtualKeyCode, wVirtualKeyCode, wVirtualScanCode, uChar, dwControlKeyState);
+			return String.format("KEY_EVENT_RECORD(%s,%s,%s,%s,%s,%s)", bKeyDown, wRepeatCount, wVirtualKeyCode, wVirtualScanCode, uChar, dwControlKeyState);
 		}
 	}
 


### PR DESCRIPTION
There were seven format items sent to the string formatter where only six are required.  One of them was duplicated, so should be removed.