### PR TITLE
Issue-620: Load ResourceBundle with default Control if custom Control fails

### DIFF
--- a/src/main/java/com/googlecode/lanterna/bundle/BundleLocator.java
+++ b/src/main/java/com/googlecode/lanterna/bundle/BundleLocator.java
@@ -70,7 +70,16 @@ public abstract class BundleLocator {
      * @return the instance of the bundle.
      */
     private ResourceBundle getBundle(Locale locale) {
-        return ResourceBundle.getBundle(bundleName, locale, loader, new UTF8Control());
+        try {
+            return ResourceBundle.getBundle(bundleName, locale, loader, new UTF8Control());
+        } catch (UnsupportedOperationException e) {
+            /*
+             * Custom Control implementations aren't supported with named modules. Since
+             * java 9 property bundles use utf-8 as default encoding so we can just load the
+             * bundle with the default Control.
+             */
+            return ResourceBundle.getBundle(bundleName, locale, loader);
+        }
     }
 
     // Taken from:


### PR DESCRIPTION
Custom control implementations are not supported in named modules. From java 9 on the default property resource bundles will use utf-8 as default charset. So we can just load the resources without the control if it fails.

Fixes #620