### PR TITLE
ENH: Support to-screen coordinates translation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,17 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- Lower to the minimum timeouts for input -->
+                        <com.googlecode.lanterna.streamTerminalSizeTimeout>10</com.googlecode.lanterna.streamTerminalSizeTimeout>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <executions>

--- a/src/main/java/com/googlecode/lanterna/graphics/AbstractTextGraphics.java
+++ b/src/main/java/com/googlecode/lanterna/graphics/AbstractTextGraphics.java
@@ -331,6 +331,29 @@ public abstract class AbstractTextGraphics implements TextGraphics {
     public TextCharacter getCharacter(TerminalPosition position) {
         return getCharacter(position.getColumn(), position.getRow());
     }
+    
+    /**
+     * Returns screen coordinates of top-left corner of this TextGraphics.
+     * The default implementation returns {@link TerminalPosition#TOP_LEFT_CORNER}.
+     * Subclasses that offset the graphics must override this method.
+     * 
+     * @return screen coordinates of top-left corner.
+     */
+    protected TerminalPosition getScreenLocation() {
+        return TerminalPosition.TOP_LEFT_CORNER;
+    }
+
+    @Override
+    public TerminalPosition toScreenPosition(TerminalPosition pos) {
+        TerminalPosition max = getScreenLocation().plus(
+                new TerminalPosition(getSize().getColumns() - 1, getSize().getRows() - 1));
+        TerminalPosition loc = getScreenLocation().plus(pos);
+        if (loc.getColumn() > max.getColumn() || loc.getRow() > max.getRow()) {
+            return null;
+        } else {
+            return loc;
+        }
+    }
 
     @Override
     public TextGraphics newTextGraphics(TerminalPosition topLeftCorner, TerminalSize size) throws IllegalArgumentException {
@@ -343,7 +366,7 @@ public abstract class AbstractTextGraphics implements TextGraphics {
             //do anything because it is impossible to change anything anyway
             return new NullTextGraphics(size);
         }
-        return new SubTextGraphics(this, topLeftCorner, size);
+        return new SubTextGraphics(this, topLeftCorner, getScreenLocation(), size);
     }
 
     private TextCharacter newTextCharacter(char character) {

--- a/src/main/java/com/googlecode/lanterna/graphics/DoublePrintingTextGraphics.java
+++ b/src/main/java/com/googlecode/lanterna/graphics/DoublePrintingTextGraphics.java
@@ -18,6 +18,7 @@
  */
 package com.googlecode.lanterna.graphics;
 
+import com.googlecode.lanterna.TerminalPosition;
 import com.googlecode.lanterna.TextCharacter;
 import com.googlecode.lanterna.TerminalSize;
 
@@ -30,6 +31,8 @@ import com.googlecode.lanterna.TerminalSize;
  * and compare it when running with the --square parameter and without.
  */
 public class DoublePrintingTextGraphics extends AbstractTextGraphics {
+    private static final TerminalPosition MULTIPLIER = new TerminalPosition(2, 1);
+
     private final TextGraphics underlyingTextGraphics;
 
     /**
@@ -59,5 +62,10 @@ public class DoublePrintingTextGraphics extends AbstractTextGraphics {
     public TerminalSize getSize() {
         TerminalSize size = underlyingTextGraphics.getSize();
         return size.withColumns(size.getColumns() / 2);
+    }
+
+    @Override
+    public TerminalPosition toScreenPosition(TerminalPosition pos) {
+        return underlyingTextGraphics.toScreenPosition(pos.multiply(MULTIPLIER));
     }
 }

--- a/src/main/java/com/googlecode/lanterna/graphics/NullTextGraphics.java
+++ b/src/main/java/com/googlecode/lanterna/graphics/NullTextGraphics.java
@@ -47,7 +47,16 @@ class NullTextGraphics implements TextGraphics {
         this.tabBehaviour = TabBehaviour.ALIGN_TO_COLUMN_4;
         this.activeModifiers = EnumSet.noneOf(SGR.class);
     }
-
+    
+    /**
+     * The default implementation just returns null, as this Graphics never writes anywhere.
+     * @param pos position to translate
+     * @return null
+     */
+    public TerminalPosition toScreenPosition(TerminalPosition pos) {
+        return null;
+    }
+    
     @Override
     public TerminalSize getSize() {
         return size;

--- a/src/main/java/com/googlecode/lanterna/graphics/SubTextGraphics.java
+++ b/src/main/java/com/googlecode/lanterna/graphics/SubTextGraphics.java
@@ -30,16 +30,23 @@ import com.googlecode.lanterna.TerminalSize;
 class SubTextGraphics extends AbstractTextGraphics {
     private final TextGraphics underlyingTextGraphics;
     private final TerminalPosition topLeft;
+    private final TerminalPosition screenTopLeft;
     private final TerminalSize writableAreaSize;
 
-    SubTextGraphics(TextGraphics underlyingTextGraphics, TerminalPosition topLeft, TerminalSize writableAreaSize) {
+    SubTextGraphics(TextGraphics underlyingTextGraphics, TerminalPosition topLeft, TerminalPosition screenRelative, TerminalSize writableAreaSize) {
         this.underlyingTextGraphics = underlyingTextGraphics;
         this.topLeft = topLeft;
         this.writableAreaSize = writableAreaSize;
+        this.screenTopLeft = screenRelative.plus(topLeft);
     }
 
     private TerminalPosition project(int column, int row) {
         return topLeft.withRelative(column, row);
+    }
+
+    @Override
+    protected TerminalPosition getScreenLocation() {
+        return screenTopLeft;
     }
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/graphics/TextGraphics.java
+++ b/src/main/java/com/googlecode/lanterna/graphics/TextGraphics.java
@@ -19,6 +19,8 @@
 package com.googlecode.lanterna.graphics;
 
 import com.googlecode.lanterna.*;
+import com.googlecode.lanterna.screen.Screen;
+import com.googlecode.lanterna.screen.ScreenTranslator;
 import com.googlecode.lanterna.screen.TabBehaviour;
 
 import java.util.Collection;
@@ -43,7 +45,7 @@ import java.util.Collection;
  * with them. The reason is that not all implementations will handle the underlying terminal changing size.
  * @author Martin
  */
-public interface TextGraphics extends StyleSet<TextGraphics> {
+public interface TextGraphics extends StyleSet<TextGraphics>, ScreenTranslator {
     /**
      * Returns the size of the area that this text graphic can write to. Any attempts of placing characters outside of
      * this area will be silently ignored.

--- a/src/main/java/com/googlecode/lanterna/graphics/TextGraphicsWriter.java
+++ b/src/main/java/com/googlecode/lanterna/graphics/TextGraphicsWriter.java
@@ -10,10 +10,11 @@ import com.googlecode.lanterna.TerminalPosition;
 import com.googlecode.lanterna.TerminalTextUtils;
 import com.googlecode.lanterna.TextCharacter;
 import com.googlecode.lanterna.TextColor;
+import com.googlecode.lanterna.screen.ScreenTranslator;
 import com.googlecode.lanterna.screen.TabBehaviour;
 import com.googlecode.lanterna.screen.WrapBehaviour;
 
-public class TextGraphicsWriter implements StyleSet<TextGraphicsWriter> {
+public class TextGraphicsWriter implements StyleSet<TextGraphicsWriter>, ScreenTranslator {
     private final TextGraphics backend;
     private TerminalPosition cursorPosition;
     private TextColor foregroundColor, backgroundColor;
@@ -292,5 +293,17 @@ public class TextGraphicsWriter implements StyleSet<TextGraphicsWriter> {
      */
     public void setStyleable(boolean styleable) {
         this.styleable = styleable;
+    }
+
+    /**
+     * Translates a position into screen coordinates. If {@code null} is specified for position,
+     * the cursor location is translated to screen coordinates.
+     * 
+     * @param pos position to translate, pass {@code null} for {@link #getCursorPosition()}.
+     * @return screen (absolute) position.
+     */
+    @Override
+    public TerminalPosition toScreenPosition(TerminalPosition pos) {
+        return backend.toScreenPosition(pos != null ? pos : getCursorPosition());
     }
 }

--- a/src/main/java/com/googlecode/lanterna/gui2/DefaultTextGUIGraphics.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/DefaultTextGUIGraphics.java
@@ -278,4 +278,8 @@ public class DefaultTextGUIGraphics implements TextGUIGraphics {
         return this;
     }
 
+    @Override
+    public TerminalPosition toScreenPosition(TerminalPosition pos) {
+        return backend.toScreenPosition(pos);
+    }
 }

--- a/src/main/java/com/googlecode/lanterna/screen/ScreenTranslator.java
+++ b/src/main/java/com/googlecode/lanterna/screen/ScreenTranslator.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of lanterna (https://github.com/mabe02/lanterna).
+ *
+ * lanterna is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2010-2020 Svatopluk Dedic
+ */
+package com.googlecode.lanterna.screen;
+
+import com.googlecode.lanterna.TerminalPosition;
+
+/**
+ * Mixin interface of an area or location object that that provides translation to screen (absolute)
+ * coordinates.
+ * 
+ * @author sdedic
+ */
+public interface ScreenTranslator {
+    /**
+     * Returns the screen on terminal coordinates of the given position within the implementing area.
+     * The result value can be used with {@link Screen} object,or its {@link Screen#newTextGraphics()},
+     * it accommodates all coordinate translations from the chain of TextGraphics.
+     * If `pos' is {@code null}, the method returns screen coordinates of origin (usually top-left corner) 
+     * of this area object.
+     * <p>
+     * Will return {@code null}, if the position is outside area implementing ScreenTranslator.
+     * 
+     * @param pos the position to translate, or {@code null} to convert position of top-left corner of this area
+     * @return screen coordinates of the given position, or origin (usually top-left corner) of this area, if `pos'
+     * is {@code null}.
+     */
+    public TerminalPosition toScreenPosition(TerminalPosition pos);
+}

--- a/src/main/java/com/googlecode/lanterna/terminal/ansi/StreamBasedTerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/ansi/StreamBasedTerminal.java
@@ -50,6 +50,10 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author Martin
  */
 public abstract class StreamBasedTerminal extends AbstractTerminal {
+    /**
+     * Timeout for detecting the terminal size, in milliseconds. Default value is 5000.
+     */
+    private static final int TERMINAL_SIZE_TIMEOUT = Integer.getInteger("com.googlecode.lanterna.streamTerminalSizeTimeout", 5000);
 
     private static final Charset UTF8_REFERENCE = StandardCharsets.UTF_8;
 
@@ -180,7 +184,7 @@ public abstract class StreamBasedTerminal extends AbstractTerminal {
         long startTime = System.currentTimeMillis();
         TerminalPosition cursorPosition = lastReportedCursorPosition;
         while(cursorPosition == null) {
-            if(System.currentTimeMillis() - startTime > 5000) {
+            if(System.currentTimeMillis() - startTime > TERMINAL_SIZE_TIMEOUT) {
                 //throw new IllegalStateException("Terminal didn't send any position report for 5 seconds, please file a bug with a reproduce!");
                 return null;
             }

--- a/src/test/java/com/googlecode/lanterna/screen/ScreenTextGraphicsTest.java
+++ b/src/test/java/com/googlecode/lanterna/screen/ScreenTextGraphicsTest.java
@@ -1,0 +1,147 @@
+/*
+ * This file is part of lanterna (https://github.com/mabe02/lanterna).
+ *
+ * lanterna is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2025 Svatopluk Dedic
+ */
+package com.googlecode.lanterna.screen;
+
+import com.googlecode.lanterna.TerminalPosition;
+import com.googlecode.lanterna.TerminalSize;
+import com.googlecode.lanterna.graphics.DoublePrintingTextGraphics;
+import com.googlecode.lanterna.graphics.TextGraphics;
+import com.googlecode.lanterna.graphics.TextGraphicsWriter;
+import com.googlecode.lanterna.terminal.DefaultTerminalFactory;
+import com.googlecode.lanterna.terminal.Terminal;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import org.junit.After;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author sdedic
+ */
+public class ScreenTextGraphicsTest {
+    Terminal terminal;
+    TerminalScreen  screen;
+    TextGraphics textGraphics;
+    TextGraphics subGraphics;
+    TerminalPosition subPosition = new TerminalPosition(10, 10);
+    TerminalSize subSize = new TerminalSize(15, 10);
+    
+    public ScreenTextGraphicsTest() {
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        // pass empty InputStream, so any read completes immediately.
+        terminal = new DefaultTerminalFactory(System.out, new ByteArrayInputStream(new byte[0]), 
+                Charset.defaultCharset()).
+                setInitialTerminalSize(new TerminalSize(120, 50)).
+                createHeadlessTerminal();
+        screen = new TerminalScreen(terminal);
+        screen.startScreen();
+
+        textGraphics = screen.newTextGraphics();
+        subGraphics = textGraphics.newTextGraphics(subPosition, subSize);
+    }
+    
+    @After 
+    public void tearDown() throws Exception {
+        screen.stopScreen(false);
+    }
+    
+    /**
+     * Checks that the root TextGraphics does not translate positions.
+     * @throws Exception 
+     */
+    @Test    public void rootToScreenPosition() throws Exception {
+        TerminalPosition pos = new TerminalPosition(3, 3);
+        
+        textGraphics.putString(pos, "Hello");
+        
+        TerminalPosition screenPos = textGraphics.toScreenPosition(pos);
+        assertEquals("H", screen.getBackCharacter(screenPos).getCharacterString());
+        assertEquals("l", screen.getBackCharacter(screenPos.withRelativeColumn(3)).getCharacterString());
+    }    
+
+    @Test
+    public void rootSubGraphicsOffset() throws Exception {
+        TerminalPosition pos = new TerminalPosition(3, 3);
+        
+        subGraphics.putString(pos, "Hello");
+        
+        assertNotEquals(pos, subGraphics.toScreenPosition(pos));
+        assertNotEquals(textGraphics.toScreenPosition(pos), subGraphics.toScreenPosition(pos));
+        
+        TerminalPosition screenPos = subGraphics.toScreenPosition(pos);
+        assertEquals("H", screen.getBackCharacter(screenPos).getCharacterString());
+        assertEquals("l", screen.getBackCharacter(screenPos.withRelativeColumn(3)).getCharacterString());
+    }    
+    
+    @Test
+    public void testPositionPastSubGraphicsSize() throws Exception {
+        TerminalPosition outOfRange = new TerminalPosition(20, 10);
+        
+        TerminalPosition toScreen = subGraphics.toScreenPosition(outOfRange);
+        assertNull(toScreen);
+    }
+
+    @Test
+    public void testPositionPastRootGraphicsSize() throws Exception {
+        TerminalPosition outOfRange = new TerminalPosition(200, 10);
+        
+        TerminalPosition toScreen = textGraphics.toScreenPosition(outOfRange);
+        assertNull(toScreen);
+    }
+    
+    @Test
+    public void testDoublePrintingGraphics() throws Exception {
+        TerminalPosition pos = new TerminalPosition(1, 2);
+        TextGraphics doubleText = new DoublePrintingTextGraphics(subGraphics);
+        doubleText.putString(pos, "Ahoj");
+        TerminalPosition screenPos = doubleText.toScreenPosition(pos);
+        TerminalPosition nextScreenPos = doubleText.toScreenPosition(pos.withRelativeColumn("Ahoj".length()));
+        
+        TerminalPosition diff = nextScreenPos.minus(screenPos);
+        assertEquals("Ahoj".length() * 2, diff.getColumn());
+        assertEquals('A', screen.getBackCharacter(screenPos).getCharacter());
+        assertEquals('j', screen.getBackCharacter(nextScreenPos.withRelativeColumn(-1)).getCharacter());
+    }
+    
+    @Test
+    public void testTextWriterPositions() throws Exception {
+        TerminalPosition pos = new TerminalPosition(3, 2);
+        TextGraphicsWriter writer = new TextGraphicsWriter(subGraphics);
+        
+        writer.setCursorPosition(pos);
+        TerminalPosition startPos = writer.toScreenPosition(null);
+        writer.putString("Ahoj");
+        
+        TerminalPosition nextPos = writer.toScreenPosition(null);
+        
+        TerminalPosition diff = nextPos.minus(startPos);
+        assertEquals("Ahoj".length(), diff.getColumn());
+        
+        assertEquals('A', screen.getBackCharacter(startPos).getCharacter());
+        assertEquals('j', screen.getBackCharacter(nextPos.withRelativeColumn(-1)).getCharacter());
+    }
+}


### PR DESCRIPTION
This PR **enhances** `TextGraphics` and `TextGraphicsWriter` (and its subclasses) in that they can translate their relative `TerminalPosition`s to the absolute `TerminalPosition`s used by the `Screen` object. 

This is useful e.g. for computing the current cursor position in an interactive application that writes to TextGraphics an user prompt and then need to position terminal cursor. Or for many other purposes.

I've added also tests to check this new behaviour.

During test development, I've realized there's a significant delay between test setup and the actual test, caused by 5s terminal wait on size query. I added a possibility to configure this delay using system properties; the system property is then used in Maven surefire configuration for test run.