### PR TITLE
Change mouse capture mode to SGR(1006)

### DIFF
--- a/src/main/java/com/googlecode/lanterna/input/MouseAction.java
+++ b/src/main/java/com/googlecode/lanterna/input/MouseAction.java
@@ -43,6 +43,23 @@ public class MouseAction extends KeyStroke {
     }
 
     /**
+     * Constructs a MouseAction based on an action type, a button and a location on the screen
+     * @param actionType The kind of mouse event
+     * @param button Which button is involved (no button = 0, left button = 1, middle (wheel) button = 2,
+     *               right button = 3, scroll wheel up = 4, scroll wheel down = 5)
+     * @param position Where in the terminal is the mouse cursor located
+     * @param ctrlDown Whether the control key was pressed when this event was generated
+     * @param altDown Whether the alt key was pressed when this event was generated
+     * @param shiftDown Whether the shift key was pressed when this event was generated
+     */
+    public MouseAction(MouseActionType actionType, int button, TerminalPosition position, boolean ctrlDown, boolean altDown, boolean shiftDown) {
+        super(KeyType.MOUSE_EVENT, ctrlDown, altDown, shiftDown);
+        this.actionType = actionType;
+        this.button = button;
+        this.position = position;
+    }
+
+    /**
      * Returns the mouse action type so the caller can determine which kind of action was performed.
      * @return The action type of the mouse event
      */
@@ -74,19 +91,19 @@ public class MouseAction extends KeyStroke {
     public TerminalPosition getPosition() {
         return position;
     }
-    
+
     public boolean isMouseDown() {
         return actionType == MouseActionType.CLICK_DOWN;
     }
-    
+
     public boolean isMouseDrag() {
         return actionType == MouseActionType.DRAG;
     }
-    
+
     public boolean isMouseMove() {
         return actionType == MouseActionType.MOVE;
     }
-    
+
     public boolean isMouseUp() {
         return actionType == MouseActionType.CLICK_RELEASE;
     }

--- a/src/main/java/com/googlecode/lanterna/terminal/ansi/ANSITerminal.java
+++ b/src/main/java/com/googlecode/lanterna/terminal/ansi/ANSITerminal.java
@@ -373,9 +373,7 @@ public abstract class ANSITerminal extends StreamBasedTerminal implements Extend
             writeCSISequenceToTerminal((byte)'?', (byte)'1', (byte)'0', (byte)'0', (byte)'3', (byte)l_or_h);
             break;
         }
-        if(getCharset().equals(StandardCharsets.UTF_8)) {
-            writeCSISequenceToTerminal((byte)'?', (byte)'1', (byte)'0', (byte)'0', (byte)'5', (byte)l_or_h);
-        }
+        writeCSISequenceToTerminal((byte)'?', (byte)'1', (byte)'0', (byte)'0', (byte)'6', (byte)l_or_h);
     }
 
     @Override


### PR DESCRIPTION
Change the mouse capture mode on Terminal based on ANSITerminal from UTF_8 (1005) to [SGR (1006)](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Extended-coordinates)  and add support for the combination of ctrl/alt/shift + mouse event (as this mode allows it to)

The main issues with mode 1005 are : 

- If the terminal is not in UTF8 there could be issues
- Java InputStreamReader converts (at least in Java 8, may be in higher versions too) some characters to 'REPLACEMENT CHARACTER' (U+FFFD), so we end up with wrong coordinates
- The button release event is not clear and does not tell which button has been released, so we have to assume which one it was

Note : This mode exists since 2012 [Xterm Changelog](https://invisible-island.net/xterm/xterm.log.html#xterm_277) and is widely supported by most SSH clients and terminals
