### PR TITLE
Patch for Issue# 605 - Read only text box is ignoring mouse scroll up or scroll down button changes

### DIFF
--- a/src/main/java/com/googlecode/lanterna/gui2/TextBox.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/TextBox.java
@@ -27,6 +27,7 @@ import com.googlecode.lanterna.TerminalSize;
 import com.googlecode.lanterna.TerminalTextUtils;
 import com.googlecode.lanterna.graphics.ThemeDefinition;
 import com.googlecode.lanterna.input.KeyStroke;
+import com.googlecode.lanterna.input.KeyType;
 import com.googlecode.lanterna.input.MouseAction;
 import com.googlecode.lanterna.input.MouseActionType;
 
@@ -659,26 +660,23 @@ public class TextBox extends AbstractInteractableComponent<TextBox> {
                 MouseAction mouseAction = (MouseAction) keyStroke;
                 MouseActionType actionType = mouseAction.getActionType();
                 if (actionType == MouseActionType.SCROLL_UP) {
-                    if (canMoveCaretUp()) {
-                        performMoveCaretUp();
-                    }
+                	return handleKeyStrokeReadOnly(new KeyStroke(KeyType.ARROW_UP));
                 } else if (actionType == MouseActionType.SCROLL_DOWN) {
-                    if (canMoveCaretDown()) {
-                        performMoveCaretDown();
-                    }
-                } else {
-                    TerminalPosition offset = getRenderer().getViewTopLeft();
-                    int newCaretPositionColumn = mouseAction.getPosition().getColumn() - getGlobalPosition().getColumn() + offset.getColumn();
-                    int newCaretPositionRow = mouseAction.getPosition().getRow() - getGlobalPosition().getRow() + offset.getRow();
-                    if (newCaretPositionRow >= 0 && newCaretPositionRow < lines.size()) {
-                        String newActiveLine = lines.get(newCaretPositionRow);
-                        int minPositionAttempt = 0;
-                        int maxPositionAttempt = newActiveLine.length();
-                        newCaretPositionColumn = Math.max(minPositionAttempt, Math.min(newCaretPositionColumn, maxPositionAttempt));
-
-                        caretPosition = caretPosition.with(new TerminalPosition(newCaretPositionColumn, newCaretPositionRow));
-                    }
+                	return handleKeyStrokeReadOnly(new KeyStroke(KeyType.ARROW_DOWN));
                 }
+                
+                TerminalPosition offset = getRenderer().getViewTopLeft();
+                int newCaretPositionColumn = mouseAction.getPosition().getColumn() - getGlobalPosition().getColumn() + offset.getColumn();
+                int newCaretPositionRow = mouseAction.getPosition().getRow() - getGlobalPosition().getRow() + offset.getRow();
+                if (newCaretPositionRow >= 0 && newCaretPositionRow < lines.size()) {
+                    String newActiveLine = lines.get(newCaretPositionRow);
+                    int minPositionAttempt = 0;
+                    int maxPositionAttempt = newActiveLine.length();
+                    newCaretPositionColumn = Math.max(minPositionAttempt, Math.min(newCaretPositionColumn, maxPositionAttempt));
+
+                    caretPosition = caretPosition.with(new TerminalPosition(newCaretPositionColumn, newCaretPositionRow));
+                }
+                
                 result = Result.HANDLED;
                 break;
         }
@@ -760,6 +758,19 @@ public class TextBox extends AbstractInteractableComponent<TextBox> {
             case PAGE_UP:
                 getRenderer().setViewTopLeft(getRenderer().getViewTopLeft().withRelativeRow(-getSize().getRows()));
                 return Result.HANDLED;
+            case MOUSE_EVENT:
+            	// Not focused
+                if (!isFocused()) { break; }
+                
+                // Only handle Scrollup or down actions
+                MouseAction mouseAction = (MouseAction) keyStroke;
+                MouseActionType actionType = mouseAction.getActionType();
+                if (actionType == MouseActionType.SCROLL_UP) {
+                	 return handleKeyStrokeReadOnly(new KeyStroke(KeyType.ARROW_UP));
+                } else if (actionType == MouseActionType.SCROLL_DOWN) {
+                	return handleKeyStrokeReadOnly(new KeyStroke(KeyType.ARROW_DOWN));
+                }     
+                return Result.HANDLED;							
             default:
         }
         return super.handleKeyStroke(keyStroke);

--- a/src/test/java/com/googlecode/lanterna/gui2/TestBase.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/TestBase.java
@@ -21,6 +21,7 @@ package com.googlecode.lanterna.gui2;
 import com.googlecode.lanterna.TestTerminalFactory;
 import com.googlecode.lanterna.bundle.LanternaThemes;
 import com.googlecode.lanterna.screen.Screen;
+import com.googlecode.lanterna.terminal.MouseCaptureMode;
 
 import java.io.IOException;
 
@@ -30,7 +31,7 @@ import java.io.IOException;
  */
 public abstract class TestBase {
     void run(String[] args) throws IOException, InterruptedException {
-        Screen screen = new TestTerminalFactory(args).createScreen();
+        Screen screen = new TestTerminalFactory(args).setMouseCaptureMode(MouseCaptureMode.CLICK_AUTODETECT).createScreen();
         screen.startScreen();
         MultiWindowTextGUI textGUI = createTextGUI(screen);
         String theme = extractTheme(args);

--- a/src/test/java/com/googlecode/lanterna/gui2/TextBoxTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/TextBoxTest.java
@@ -39,8 +39,8 @@ public class TextBoxTest extends TestBase {
         leftPanel.addComponent(new TextBox("Some text").withBorder(Borders.singleLine("With init")));
         leftPanel.addComponent(new TextBox(new TerminalSize(10, 1), "Here is some text that is too long to fit in the text box").withBorder(Borders.singleLine("Long text")));
         leftPanel.addComponent(new TextBox("password").setMask('*').withBorder(Borders.singleLine("Password")));
-
         rightPanel.addComponent(new TextBox(new TerminalSize(15, 5),
+        		"This is a normal TextBox.  The mouse handling should work when focused.\n" +
                 "Well here we are again\n" +
                 "It's always such a pleasure\n" +
                 "Remember when you tried\n" +
@@ -50,7 +50,18 @@ public class TextBoxTest extends TestBase {
                 "私は笑っていませんが\n" +
                 "状況を振り返ると\n" +
                 "自分のやさしさに驚くほどです").withBorder(Borders.singleLine()));
-
+        rightPanel.addComponent(new TextBox(new TerminalSize(15, 5),
+        		"This is a read-only TextBox.  The mouse handling should continue to work when focused.\n" +
+                "Well here we are again\n" +
+                "It's always such a pleasure\n" +
+                "Remember when you tried\n" +
+                "to kill me twice?\n" +
+                "\n" +
+                "あのときは笑いが止まりませんでしたね\n" +
+                "私は笑っていませんが\n" +
+                "状況を振り返ると\n" +
+                "自分のやさしさに驚くほどです").setReadOnly(true).withBorder(Borders.singleLine()));
+        
         mainPanel.addComponent(leftPanel.withBorder(Borders.singleLine("Single line")));
         mainPanel.addComponent(rightPanel.withBorder(Borders.singleLine("Multiline")));
 


### PR DESCRIPTION
Read only text box is ignoring mouse scroll up or scroll down button changes

- Updated both handleKeyStrokeXX() functions to utilize exiting ARROW_UP/ARROW_DOWN code to handle when VerticalFocus is changing
- Added auto detect mouse to TextBase so user can see changes
- Added 'read-only' text box to TextBoxTest Junit to demonstrate