### PR TITLE
Patch for Issue #650 - Fix MODAL issues

### DIFF
--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractInteractableComponent.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractInteractableComponent.java
@@ -215,7 +215,7 @@ public abstract class AbstractInteractableComponent<T extends AbstractInteractab
             isMouseActivation = action.getActionType() == MouseActionType.CLICK_DOWN;
         }
         
-        return isMouseActivation;
+        return isFocused() && isMouseActivation;
     }
     
     public boolean isActivationStroke(KeyStroke keyStroke) {

--- a/src/main/java/com/googlecode/lanterna/gui2/MultiWindowTextGUI.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/MultiWindowTextGUI.java
@@ -382,8 +382,14 @@ public class MultiWindowTextGUI extends AbstractTextGUI implements WindowBasedTe
             List<Window> snapshot = new ArrayList<>(getWindows());
             for (Window w : snapshot) {
                 w.getBounds().whenContains(mouse.getPosition(), () -> {
-                    setActiveWindow(w);
-                    anyHit.set(true);
+                	// Only change active window if the active MODAL dialog or if 
+                	// window is not MODAL 
+                	if (!priorActiveWindow.getHints().contains(Hint.MODAL) ||
+                		(priorActiveWindow.getHints().contains(Hint.MODAL) && w == priorActiveWindow))
+                	{
+                		setActiveWindow(w);
+                		anyHit.set(true);
+                	}                	
                 });
             }
             // clear popup menus if they clicked onto another window or missed all windows

--- a/src/main/java/com/googlecode/lanterna/gui2/dialogs/MessageDialogBuilder.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/dialogs/MessageDialogBuilder.java
@@ -46,6 +46,7 @@ public class MessageDialogBuilder {
         this.buttons = new ArrayList<>();
         this.extraWindowHints = new HashSet<>();
         this.extraWindowHints.add(Window.Hint.CENTERED);
+        this.extraWindowHints.add(Window.Hint.MODAL);        
     }
 
     /**

--- a/src/test/java/com/googlecode/lanterna/gui2/DialogsTextGUIBasicTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/DialogsTextGUIBasicTest.java
@@ -22,6 +22,7 @@ import com.googlecode.lanterna.TerminalSize;
 import com.googlecode.lanterna.TestTerminalFactory;
 import com.googlecode.lanterna.gui2.dialogs.*;
 import com.googlecode.lanterna.screen.Screen;
+import com.googlecode.lanterna.terminal.MouseCaptureMode;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,7 +34,7 @@ import java.util.regex.Pattern;
  */
 public class DialogsTextGUIBasicTest {
     public static void main(String[] args) throws IOException {
-        Screen screen = new TestTerminalFactory(args).createScreen();
+        Screen screen = new TestTerminalFactory(args).setMouseCaptureMode(MouseCaptureMode.CLICK_AUTODETECT).createScreen();
         screen.startScreen();
         final WindowBasedTextGUI textGUI = new MultiWindowTextGUI(screen);
         try {


### PR DESCRIPTION
- Add MODAL hint to MessageBoxBuilder
- Added check for 'MODAL' in the MultiWindowTextGUI class
- Add check to see if the component has focus in AbstractInteractableComponent class
- Added setMouseCapture() to the DialogsTextGUIBasicText

To recreate:
1. run the DialogsTextGUIBasicText as app
2. Open any of the dialogs
3. Click anywhere not on the dialog, the focus will be changed to the area clicked on.

To validate:
- rerun but in Step 3.  focus should not leave the dialog until the button is pressed.