### PR TITLE
Dead code refactor: Removed depreccated code from Table.java

### DIFF
--- a/src/main/java/com/googlecode/lanterna/gui2/table/Table.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/table/Table.java
@@ -214,16 +214,6 @@ public class Table<V> extends AbstractInteractableComponent<Table<V>> {
         return visibleRows;
     }
 
-    /**
-     * Returns the index of the row that is currently the first row visible. This is always 0 unless scrolling has been
-     * enabled and either the user or the software (through {@code setViewTopRow(..)}) has scrolled down.
-     * @return Index of the row that is currently the first row visible
-     * @deprecated Use the table renderers method instead
-     */
-    @Deprecated
-    public int getViewTopRow() {
-        return getRenderer().getViewTopRow();
-    }
     
     /**
      * Returns the index of the first row that is currently visible.
@@ -240,20 +230,6 @@ public class Table<V> extends AbstractInteractableComponent<Table<V>> {
     public int getLastViewedRowIndex() {
         int visibleRows = getRenderer().getVisibleRowsOnLastDraw();
         return Math.min(getRenderer().getViewTopRow() + visibleRows -1, tableModel.getRowCount() -1);
-    }
-
-    /**
-     * Sets the view row offset for the first row to display in the table. Calling this with 0 will make the first row
-     * in the model be the first visible row in the table.
-     *
-     * @param viewTopRow Index of the row that is currently the first row visible
-     * @return Itself
-     * @deprecated Use the table renderers method instead
-     */
-    @Deprecated
-    public synchronized Table<V> setViewTopRow(int viewTopRow) {
-        getRenderer().setViewTopRow(viewTopRow);
-        return this;
     }
 
     /**
@@ -524,5 +500,4 @@ public class Table<V> extends AbstractInteractableComponent<Table<V>> {
         }
         return column;
     }
-
 }


### PR DESCRIPTION
##  Dead Code – Deprecated API Removal

**File:**  
`src/main/java/com/googlecode/lanterna/gui2/table/Table.java`

**Severity:**  
Low

## Description

The `Table` class contains two public methods, `getViewTopRow()` and `setViewTopRow(int)`, that are marked as `@Deprecated`. These methods are no longer maintained and simply act as wrappers around newer APIs that provide the same functionality.

## Why It Is Problematic

Deprecated methods increase the public API surface and contribute to technical debt. Maintaining legacy wrapper methods makes the codebase harder to understand and increases maintenance effort. Since modern replacement methods already exist, keeping the deprecated methods provides little value while increasing the risk of future compatibility issues.

## Evidence

The methods `getViewTopRow()` and `setViewTopRow(int)` are annotated with `@Deprecated` in `Table.java`. The class already provides the recommended replacement methods:

- `getViewTopRow()` → `getFirstViewedRowIndex()`
- `setViewTopRow(int)` → `getRenderer().setViewTopRow(int)`

A project-wide search shows no internal usages of these deprecated methods outside `Table.java`, indicating that they are effectively unused within the codebase.

## Recommended Improvement

Remove the deprecated wrapper methods from `Table.java` and update any remaining external code to use the modern APIs:

- Replace `getViewTopRow()` with `getFirstViewedRowIndex()`.
- Replace `setViewTopRow(int)` with `getRenderer().setViewTopRow(int)`.

If these methods are removed in a future release, the API change should be documented in the project's changelog.