### PR TITLE
`ScrollViewer` with Content-Assisted Scrolling

### DIFF
--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractBasePane.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractBasePane.java
@@ -247,9 +247,28 @@ public abstract class AbstractBasePane<T extends BasePane> implements BasePane {
         Interactable previous = focusedInteractable;
         focusedInteractable = toFocus;
         if(toFocus != null) {
+            bringIntoView(toFocus);
             toFocus.onEnterFocus(direction, previous);
         }
         invalidate();
+    }
+
+    private void bringIntoView(final Component c) {
+        if (c == null) {
+            return;
+        }
+        final ScrollViewer scrollViewer = ScrollViewer.findScrollViewer(c);
+        if (scrollViewer == null) {
+            return;
+        }
+        TerminalSize size = c.getSize();
+        if (size == null) {
+            size = c.getPreferredSize();
+        }
+        if (size == null || size.getRows() == 0 || size.getColumns() == 0) {
+            return;
+        }
+        scrollViewer.makeVisible(c, Rectangle.of(TerminalPosition.TOP_LEFT_CORNER, size));
     }
 
     @Override

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractComponent.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractComponent.java
@@ -341,6 +341,21 @@ public abstract class AbstractComponent<T extends Component> implements Componen
     }
 
     @Override
+    public TerminalPosition toAncestor(Component ancestor, TerminalPosition position) {
+        if (ancestor == this) {
+            return position;
+        }
+        if (ancestor == null) {
+            return null;
+        }
+        Container parent = getParent();
+        if (parent != null) {
+            return parent.toAncestor(ancestor, getPosition().withRelative(position));
+        }
+        return null;
+    }
+
+    @Override
     public TerminalPosition toGlobal(TerminalPosition position) {
         Container parent = getParent();
         if(parent == null) {

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractInteractableComponent.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractInteractableComponent.java
@@ -20,6 +20,7 @@ package com.googlecode.lanterna.gui2;
 
 import com.googlecode.lanterna.TerminalPosition;
 import com.googlecode.lanterna.input.KeyStroke;
+import com.googlecode.lanterna.input.KeyType;
 
 /**
  * Default implementation of Interactable that extends from AbstractComponent. If you want to write your own component
@@ -156,24 +157,30 @@ public abstract class AbstractInteractableComponent<T extends AbstractInteractab
      */
     protected Result handleKeyStroke(KeyStroke keyStroke) {
         // Skip the keystroke if ctrl, alt or shift was down
-        if(!keyStroke.isAltDown() && !keyStroke.isCtrlDown() && !keyStroke.isShiftDown()) {
-            switch(keyStroke.getKeyType()) {
-                case ArrowDown:
-                    return Result.MOVE_FOCUS_DOWN;
-                case ArrowLeft:
-                    return Result.MOVE_FOCUS_LEFT;
-                case ArrowRight:
-                    return Result.MOVE_FOCUS_RIGHT;
-                case ArrowUp:
-                    return Result.MOVE_FOCUS_UP;
-                case Tab:
-                    return Result.MOVE_FOCUS_NEXT;
-                case ReverseTab:
-                    return Result.MOVE_FOCUS_PREVIOUS;
-                case MouseEvent:
-                    getBasePane().setFocusedInteractable(this);
-                    return Result.HANDLED;
-                default:
+        if(!keyStroke.isAltDown() && !keyStroke.isCtrlDown()) {
+            if(!keyStroke.isShiftDown()) {
+                switch(keyStroke.getKeyType()) {
+                    case ArrowDown:
+                        return Result.MOVE_FOCUS_DOWN;
+                    case ArrowLeft:
+                        return Result.MOVE_FOCUS_LEFT;
+                    case ArrowRight:
+                        return Result.MOVE_FOCUS_RIGHT;
+                    case ArrowUp:
+                        return Result.MOVE_FOCUS_UP;
+                    case Tab:
+                        return Result.MOVE_FOCUS_NEXT;
+                    case ReverseTab:
+                        return Result.MOVE_FOCUS_PREVIOUS;
+                    case MouseEvent:
+                        getBasePane().setFocusedInteractable(this);
+                        return Result.HANDLED;
+                    default:
+                }
+            }
+            // On Mac at least, Shift+Tab is ReverseTab, and isShiftDown() always reports `true`.
+            if (keyStroke.getKeyType() == KeyType.ReverseTab) {
+                return Result.MOVE_FOCUS_PREVIOUS;
             }
         }
         return Result.UNHANDLED;

--- a/src/main/java/com/googlecode/lanterna/gui2/AbstractScrollableComponent.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/AbstractScrollableComponent.java
@@ -1,0 +1,155 @@
+package com.googlecode.lanterna.gui2;
+
+import com.googlecode.lanterna.TerminalSize;
+
+public abstract class AbstractScrollableComponent<T extends Component>
+    extends AbstractComponent<T>
+    implements ScrollController {
+
+    private ScrollableContentAdapter.ScrollData scrollData;
+
+    @Override
+    public void lineUp() {
+        setVerticalOffset(getVerticalOffset() - 1);
+    }
+
+    @Override
+    public void lineDown() {
+        setVerticalOffset(getVerticalOffset() + 1);
+    }
+
+    @Override
+    public void lineLeft() {
+        setHorizontalOffset(getHorizontalOffset() - 1);
+    }
+
+    @Override
+    public void lineRight() {
+        setHorizontalOffset(getHorizontalOffset() + 1);
+    }
+
+    @Override
+    public void pageUp() {
+        setVerticalOffset(getVerticalOffset() - getViewportHeight());
+    }
+
+    @Override
+    public void pageDown() {
+        setVerticalOffset(getVerticalOffset() + getViewportHeight());
+    }
+
+    @Override
+    public void pageLeft() {
+        setHorizontalOffset(getHorizontalOffset() - getViewportWidth());
+    }
+
+    @Override
+    public void pageRight() {
+        setHorizontalOffset(getHorizontalOffset() + getViewportWidth());
+    }
+
+    @Override
+    public int getHorizontalOffset() {
+        return ensureScrollData().computedHorizontalOffset;
+    }
+
+    @Override
+    public void setHorizontalOffset(final int offset) {
+        final int newOffset = ScrollableContentAdapter.validateInputOffset(offset);
+        if (newOffset != ensureScrollData().horizontalOffset) {
+            scrollData.horizontalOffset = newOffset;
+            invalidate();
+        }
+    }
+
+    @Override
+    public int getVerticalOffset() {
+        return ensureScrollData().computedVerticalOffset;
+    }
+
+    @Override
+    public void setVerticalOffset(final int offset) {
+        final int newOffset = ScrollableContentAdapter.validateInputOffset(offset);
+        if (newOffset != ensureScrollData().verticalOffset) {
+            scrollData.verticalOffset = newOffset;
+            invalidate();
+        }
+    }
+
+    @Override
+    public boolean isVerticalScrollingEnabled() {
+        return ensureScrollData().canVerticallyScroll;
+    }
+
+    @Override
+    public void setVerticalScrollingEnabled(final boolean value) {
+        if (value != ensureScrollData().canVerticallyScroll) {
+            scrollData.canVerticallyScroll = true;
+            invalidate();
+        }
+    }
+
+    @Override
+    public boolean isHorizontalScrollingEnabled() {
+        return ensureScrollData().canHorizontallyScroll;
+    }
+
+    @Override
+    public void setHorizontalScrollingEnabled(final boolean value) {
+        if (value != ensureScrollData().canHorizontallyScroll) {
+            scrollData.canHorizontallyScroll = true;
+            invalidate();
+        }
+    }
+
+    @Override
+    public int getViewportWidth() {
+        return ensureScrollData().viewportWidth;
+    }
+
+    @Override
+    public int getViewportHeight() {
+        return ensureScrollData().viewportHeight;
+    }
+
+    @Override
+    public int getExtentWidth() {
+        return ensureScrollData().extentWidth;
+    }
+
+    @Override
+    public int getExtentHeight() {
+        return ensureScrollData().extentHeight;
+    }
+
+    @Override
+    public Rectangle makeVisible(final Component component, final Rectangle targetRectangle) {
+        return ScrollableContentAdapter.makeVisible(component, this, targetRectangle, true);
+    }
+
+    @Override
+    public ScrollViewer getScrollOwner() {
+        return ensureScrollData().scrollOwner;
+    }
+
+    @Override
+    public void setScrollOwner(final ScrollViewer owner) {
+        ensureScrollData().scrollOwner = owner;
+    }
+
+    private ScrollableContentAdapter.ScrollData ensureScrollData() {
+        final ScrollableContentAdapter.ScrollData scrollData = this.scrollData;
+        return scrollData != null ? scrollData
+                                  : (this.scrollData = new ScrollableContentAdapter.ScrollData(this));
+    }
+
+    protected void updateScrollData(final TerminalSize viewport, final TerminalSize extent) {
+        ScrollableContentAdapter.verifyScrollData(ensureScrollData(), viewport, extent);
+    }
+
+    @Override
+    protected void onBeforeDrawing() {
+        updateScrollData(getSize(), getPreferredSize());
+        super.onBeforeDrawing();
+    }
+}

--- a/src/main/java/com/googlecode/lanterna/gui2/Component.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/Component.java
@@ -185,6 +185,19 @@ public interface Component extends TextGUIElement {
     TerminalPosition toBasePane(TerminalPosition position);
 
     /**
+     * Translates a position in this component's coordinate space to the coordinate space of an ancestor.
+     * If this component is not a descendant of {@code ancestor}, then this method will return {@code null}.
+     * {@code null}.  If {@code ancestor} is the same instance as this component, {@code position} will be
+     * unchanged.
+     *
+     * @param ancestor A direct or transitive parent component.
+     * @param position The position to translate (relative to the top-left corner of this component's container)
+     * @return Position in the ancestor component's space, or {@code null} if the component is not a descendant of
+     * {@code ancestor}
+     */
+    TerminalPosition toAncestor(Component ancestor, TerminalPosition position);
+
+    /**
      * Translates a position local to the container to global coordinate space. This should be the absolute coordinate
      * in the terminal screen, taking no windows or containers into account. If the component belongs to no base pane,
      * it will return {@code null}.

--- a/src/main/java/com/googlecode/lanterna/gui2/Rectangle.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/Rectangle.java
@@ -29,7 +29,7 @@ public final class Rectangle {
     }
 
     public static Rectangle of(final TerminalSize size) {
-        return new Rectangle(TerminalPosition.OFFSET_1x1, size);
+        return new Rectangle(TerminalPosition.TOP_LEFT_CORNER, size);
     }
 
     public static Rectangle of(final int x, final int y, final int width, final int height) {

--- a/src/main/java/com/googlecode/lanterna/gui2/Rectangle.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/Rectangle.java
@@ -3,6 +3,9 @@ package com.googlecode.lanterna.gui2;
 import com.googlecode.lanterna.TerminalPosition;
 import com.googlecode.lanterna.TerminalSize;
 
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
 public final class Rectangle {
     public static final Rectangle EMPTY = new Rectangle(TerminalPosition.TOP_LEFT_CORNER, TerminalSize.ZERO);
 
@@ -10,8 +13,12 @@ public final class Rectangle {
     private final TerminalPosition position;
 
     private Rectangle(final TerminalPosition position, final TerminalSize size) {
-        if (size == null) throw new NullPointerException("Size cannot be null.");
-        if (position == null) throw new NullPointerException("Position cannot be null.");
+        if (size == null) {
+            throw new NullPointerException("Size cannot be null.");
+        }
+        if (position == null) {
+            throw new NullPointerException("Position cannot be null.");
+        }
 
         this.size = size;
         this.position = position;
@@ -63,5 +70,90 @@ public final class Rectangle {
 
     public boolean isEmpty() {
         return size.getColumns() == 0 && size.getRows() == 0;
+    }
+
+    public boolean intersectsWith(final Rectangle r) {
+        return !isEmpty() &&
+               !r.isEmpty() &&
+               r.getLeft() <= getRight() &&
+               r.getRight() >= getLeft() &&
+               r.getTop() <= getBottom() &&
+               r.getBottom() >= getTop();
+    }
+
+    public Rectangle intersection(final Rectangle r) {
+        if (!this.intersectsWith(r)) {
+            return EMPTY;
+        }
+
+        return new Rectangle(
+            new TerminalPosition(
+                max(getLeft(), r.getLeft()),
+                max(getTop(), r.getTop())
+            ),
+            new TerminalSize(
+                max(min(getRight(), r.getRight()) - max(getLeft(), r.getLeft()), 0),
+                max(min(getBottom(), r.getBottom()) - max(getTop(), r.getTop()), 0)
+            )
+        );
+    }
+
+    public Rectangle union(final Rectangle rectangle) {
+        if (isEmpty()) {
+            return rectangle;
+        }
+
+        if (rectangle.isEmpty()) {
+            return this;
+        }
+
+        final int left = min(getLeft(), rectangle.getLeft());
+        final int top = min(getTop(), rectangle.getTop());
+        final int width = max(max(getRight(), rectangle.getRight()) - left, 0);
+        final int height = max(max(getBottom(), rectangle.getBottom()) - top, 0);
+
+        return new Rectangle(new TerminalPosition(left, top), new TerminalSize(width, height));
+    }
+
+    public Rectangle offset(final TerminalPosition relativeOffset) {
+        return offset(relativeOffset.getColumn(), relativeOffset.getRow());
+    }
+
+    public Rectangle offset(final int deltaX, final int deltaY) {
+        if (isEmpty()) {
+            throw new IllegalStateException("Cannot offset an empty Rectangle.");
+        }
+
+        if (deltaX == 0 && deltaY == 0) {
+            return this;
+        }
+
+        return new Rectangle(
+            new TerminalPosition(getLeft() + deltaX, getTop() + deltaY),
+            getSize()
+        );
+    }
+
+    public boolean contains(final int column, final int row) {
+        return column >= getLeft() &&
+               column <= getRight() &&
+               row >= getTop() &&
+               row <= getBottom();
+    }
+
+    public boolean contains(final TerminalPosition position) {
+        return contains(position.getColumn(), position.getRow());
+    }
+
+    public boolean contains(final Rectangle rectangle) {
+        return rectangle.getLeft() >= getLeft() &&
+               rectangle.getRight() <= getRight() &&
+               rectangle.getTop() >= getTop() &&
+               rectangle.getBottom() <= getBottom();
+    }
+
+    @Override
+    public String toString() {
+        return "[" + getWidth() + 'x' + getHeight() + " at " + getLeft() + ',' + getTop() + ']';
     }
 }

--- a/src/main/java/com/googlecode/lanterna/gui2/Rectangle.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/Rectangle.java
@@ -1,0 +1,67 @@
+package com.googlecode.lanterna.gui2;
+
+import com.googlecode.lanterna.TerminalPosition;
+import com.googlecode.lanterna.TerminalSize;
+
+public final class Rectangle {
+    public static final Rectangle EMPTY = new Rectangle(TerminalPosition.TOP_LEFT_CORNER, TerminalSize.ZERO);
+
+    private final TerminalSize size;
+    private final TerminalPosition position;
+
+    private Rectangle(final TerminalPosition position, final TerminalSize size) {
+        if (size == null) throw new NullPointerException("Size cannot be null.");
+        if (position == null) throw new NullPointerException("Position cannot be null.");
+
+        this.size = size;
+        this.position = position;
+    }
+
+    public static Rectangle of(final TerminalPosition position, final TerminalSize size) {
+        return new Rectangle(position, size);
+    }
+
+    public static Rectangle of(final TerminalSize size) {
+        return new Rectangle(TerminalPosition.OFFSET_1x1, size);
+    }
+
+    public static Rectangle of(final int x, final int y, final int width, final int height) {
+        return new Rectangle(new TerminalPosition(x, y), new TerminalSize(width, height));
+    }
+
+    public TerminalSize getSize() {
+        return size;
+    }
+
+    public TerminalPosition getPosition() {
+        return position;
+    }
+
+    public int getWidth() {
+        return size.getColumns();
+    }
+
+    public int getHeight() {
+        return size.getRows();
+    }
+
+    public int getLeft() {
+        return position.getColumn();
+    }
+
+    public int getTop() {
+        return position.getRow();
+    }
+
+    public int getRight() {
+        return getLeft() + getWidth() - 1;
+    }
+
+    public int getBottom() {
+        return getTop() + getHeight() - 1;
+    }
+
+    public boolean isEmpty() {
+        return size.getColumns() == 0 && size.getRows() == 0;
+    }
+}

--- a/src/main/java/com/googlecode/lanterna/gui2/ScrollBarPolicy.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/ScrollBarPolicy.java
@@ -1,0 +1,25 @@
+package com.googlecode.lanterna.gui2;
+
+public enum ScrollBarPolicy {
+    /**
+     * No scrollbar is ever shown, and scrolling is not allowed in this dimension.
+     */
+    DISABLED,
+
+    /**
+     * The scrollbar is shown only when the content exceeds the size of hte viewport
+     * in this dimension.
+     */
+    AUTO,
+
+    /**
+     * No scrollbar is ever shown, and no space will be reserved for it, though
+     * scrolling may still occur by other means.
+     */
+    HIDDEN,
+
+    /**
+     * The scrollbar will always be visible, and space always reserved for it.
+     */
+    VISIBLE
+}

--- a/src/main/java/com/googlecode/lanterna/gui2/ScrollController.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/ScrollController.java
@@ -1,6 +1,6 @@
 package com.googlecode.lanterna.gui2;
 
-public interface Scrollable {
+public interface ScrollController {
     int INFINITY = Integer.MAX_VALUE;
 
     void lineUp();
@@ -30,6 +30,8 @@ public interface Scrollable {
     int getExtentWidth();
     int getExtentHeight();
 
-    ScrollOwner getScrollOwner();
-    void setScrollOwner(ScrollOwner owner);
+    Rectangle makeVisible(Component component, Rectangle targetRectangle);
+
+    ScrollViewer getScrollOwner();
+    void setScrollOwner(ScrollViewer owner);
 }

--- a/src/main/java/com/googlecode/lanterna/gui2/ScrollOwner.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/ScrollOwner.java
@@ -1,7 +1,0 @@
-package com.googlecode.lanterna.gui2;
-
-public interface ScrollOwner {
-    void invalidateScrollInfo();
-    Scrollable getScrollController();
-    void setScrollController(Scrollable controller);
-}

--- a/src/main/java/com/googlecode/lanterna/gui2/ScrollOwner.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/ScrollOwner.java
@@ -1,0 +1,7 @@
+package com.googlecode.lanterna.gui2;
+
+public interface ScrollOwner {
+    void invalidateScrollInfo();
+    Scrollable getScrollController();
+    void setScrollController(Scrollable controller);
+}

--- a/src/main/java/com/googlecode/lanterna/gui2/ScrollViewer.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/ScrollViewer.java
@@ -15,7 +15,7 @@ import static java.lang.Math.max;
 
 public class ScrollViewer
     extends AbstractComponent<ScrollViewer>
-    implements Composite, Container, ScrollOwner/*, Interactable*/ {
+    implements Composite, Container, ScrollOwner {
 
     private final ScrollBar horizontalScrollBar;
     private final ScrollBar verticalScrollBar;
@@ -469,8 +469,6 @@ public class ScrollViewer
 
     // <editor-fold defaultstate="collapsed" desc="Layout">
 
-    private TerminalSize desiredSize;
-
     private boolean isLayoutInProgress;
     private boolean isLayoutInvalidatedFromRender;
     private boolean isRenderInProgress;
@@ -481,14 +479,14 @@ public class ScrollViewer
 
     @Override
     public void invalidate() {
-        desiredSize = null;
-
         if (isRenderInProgress) {
+            if (!isLayoutInvalidatedFromRender) {
+                ensureLayoutUpdater();
+            }
             isLayoutInvalidatedFromRender = true;
         }
 
         setPreferredSize(null);
-//        setSize(null);
 
         super.invalidate();
     }
@@ -564,6 +562,7 @@ public class ScrollViewer
         if (changed) {
             try {
                 onScrollChanged();
+                invalidate();
                 return;
             }
             finally {
@@ -726,10 +725,6 @@ public class ScrollViewer
             }
         }
 
-        final void enqueue(final CommandCode code) {
-            enqueue(code, 0);
-        }
-
         final void enqueue(final CommandCode code, final int parameter) {
             if (!optimizeCommand(code, parameter)) {
                 final int newWritePosition = (lastWritePosition + 1) % CAPACITY;
@@ -842,7 +837,6 @@ public class ScrollViewer
     }
 
     private final static class ScrollViewerRenderer implements ComponentRenderer<ScrollViewer> {
-        private TerminalSize totalSize;
         private TerminalSize desiredChildSize;
         private TerminalSize hBarSize;
         private TerminalSize vBarSize;
@@ -883,8 +877,6 @@ public class ScrollViewer
             finally {
                 sv.isLayoutInProgress = wasLayoutInProgress;
             }
-
-            totalSize = desiredSize;
 
             return desiredSize;
         }
@@ -928,7 +920,7 @@ public class ScrollViewer
                     );
                 }
 
-                sv.updateLayout();
+//                sv.updateLayout();
 
                 sv.horizontalScrollBar.setViewSize(sv.getViewportWidth());
                 sv.horizontalScrollBar.setScrollMaximum(sv.getExtentWidth());
@@ -1042,81 +1034,4 @@ public class ScrollViewer
     }
 
     // </editor-fold>
-
-//    // <editor-fold defaultstate="collapsed" desc="Interactable Implementation">
-//
-//    boolean ifFocused;
-//    boolean isEnabled;
-//
-//    @Override
-//    public TerminalPosition getCursorLocation() {
-//        return null;
-//    }
-//
-//    @Override
-//    public Interactable takeFocus() {
-//        if(!isEnabled()) {
-//            return self();
-//        }
-//
-//        final BasePane basePane = getBasePane();
-//
-//        if(basePane != null) {
-//            basePane.setFocusedInteractable(this);
-//        }
-//
-//        return self();
-//    }
-//
-//    @Override
-//    public void onEnterFocus(FocusChangeDirection direction, Interactable previouslyInFocus) {
-//        ifFocused = true;
-//    }
-//
-//    @Override
-//    public void onLeaveFocus(FocusChangeDirection direction, Interactable nextInFocus) {
-//        ifFocused = false;
-//    }
-//
-//    @Override
-//    public boolean isFocused() {
-//        return ifFocused;
-//    }
-//
-//    @Override
-//    public Interactable setInputFilter(InputFilter inputFilter) {
-//        return this;
-//    }
-//
-//    @Override
-//    public InputFilter getInputFilter() {
-//        return null;
-//    }
-//
-//    @Override
-//    public Interactable setEnabled(boolean enabled) {
-//        isEnabled = enabled;
-//
-//        if (!enabled && isFocused()) {
-//            final BasePane basePane = getBasePane();
-//
-//            if (basePane != null) {
-//                basePane.setFocusedInteractable(null);
-//            }
-//        }
-//
-//        return self();
-//    }
-//
-//    @Override
-//    public boolean isEnabled() {
-//        return isEnabled;
-//    }
-//
-//    @Override
-//    public boolean isFocusable() {
-//        return false;
-//    }
-//
-//    // </editor-fold>
 }

--- a/src/main/java/com/googlecode/lanterna/gui2/ScrollViewer.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/ScrollViewer.java
@@ -1,0 +1,1122 @@
+package com.googlecode.lanterna.gui2;
+
+import com.googlecode.lanterna.TerminalPosition;
+import com.googlecode.lanterna.TerminalSize;
+import com.googlecode.lanterna.input.KeyStroke;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static com.googlecode.lanterna.gui2.ScrollableContentAdapter.validateInputOffset;
+import static java.lang.Math.max;
+
+public class ScrollViewer
+    extends AbstractComponent<ScrollViewer>
+    implements Composite, Container, ScrollOwner/*, Interactable*/ {
+
+    private final ScrollBar horizontalScrollBar;
+    private final ScrollBar verticalScrollBar;
+    private final ScrollableContentAdapter contentAdapter;
+
+    private Component component;
+    private ComponentRenderer<ScrollViewer> renderer;
+    private Scrollable scrollController;
+    private ScrollBarPolicy horizontalScrollBarPolicy = ScrollBarPolicy.AUTO;
+    private ScrollBarPolicy verticalScrollBarPolicy = ScrollBarPolicy.AUTO;
+
+    private boolean computedHorizontalScrollingEnabled;
+    private boolean computedVerticalScrollingEnabled;
+    private int cachedHorizontalOffset;
+    private int cachedVerticalOffset;
+    private int cachedExtentHeight;
+    private int cachedExtentWidth;
+    private int cachedViewportWidth;
+    private int cachedViewportHeight;
+
+    public ScrollViewer() {
+        horizontalScrollBar = new ScrollBar(Direction.HORIZONTAL);
+        verticalScrollBar = new ScrollBar(Direction.VERTICAL);
+        contentAdapter = new ScrollableContentAdapter();
+    }
+
+    private int visibleChildren() {
+        int result = 0;
+
+        if (component != null) {
+            result |= VISIBLE_CHILD;
+        }
+
+        if (computedVerticalScrollingEnabled) {
+            result |= VISIBLE_V_BAR;
+        }
+
+        if (computedHorizontalScrollingEnabled) {
+            result |= VISIBLE_H_BAR;
+        }
+
+        return result;
+    }
+
+    @Override
+    public final int getChildCount() {
+        return Integer.bitCount(visibleChildren());
+    }
+
+    @Override
+    public final Collection<Component> getChildren() {
+        final int visibleChildren = visibleChildren();
+
+        if (visibleChildren == 0) {
+            return Collections.emptyList();
+        }
+
+        if (visibleChildren == VISIBLE_CHILD) {
+            return Collections.singletonList(component);
+        }
+
+        final List<Component> children = new ArrayList<Component>(3);
+
+        if ((visibleChildren & VISIBLE_CHILD) != 0) {
+            children.add(component);
+        }
+
+        if ((visibleChildren & VISIBLE_V_BAR) != 0) {
+            children.add(verticalScrollBar);
+        }
+
+        if ((visibleChildren & VISIBLE_H_BAR) != 0) {
+            children.add(horizontalScrollBar);
+        }
+
+        return children;
+    }
+
+    @Override
+    public final Component getComponent() {
+        return component;
+    }
+
+    @Override
+    public final void setComponent(final Component component) {
+        final Component oldComponent = this.component;
+
+        if (oldComponent == component) {
+            return;
+        }
+
+        if (oldComponent != null) {
+            removeComponent(oldComponent);
+        }
+
+        if (component != null) {
+            this.component = component;
+            component.onAdded(this);
+            component.setPosition(TerminalPosition.TOP_LEFT_CORNER);
+            contentAdapter.setAdaptedComponent(component);
+            invalidate();
+        }
+    }
+
+    @Override
+    public boolean containsComponent(final Component component) {
+        return component != null && component.hasParent(this);
+    }
+
+    @Override
+    public boolean removeComponent(final Component component) {
+        if (component == this.component) {
+            contentAdapter.setAdaptedComponent(null);
+            this.component = null;
+            clearCachedLayout();
+            component.onRemoved(this);
+            invalidate();
+            return true;
+        }
+        return false;
+    }
+
+    // <editor-fold defaultstate="collapsed" desc="Input Handling">
+
+    @Override
+    public boolean handleInput(final KeyStroke key) {
+        return scrollInDirection(key);
+    }
+
+    @Override
+    public void updateLookupMap(final InteractableLookupMap map) {
+        final Component component = getComponent();
+
+        if (component instanceof Container) {
+            ((Container) getComponent()).updateLookupMap(map);
+        }
+        else if (getComponent() instanceof Interactable) {
+            map.add((Interactable) getComponent());
+        }
+    }
+
+    @Override
+    public Interactable nextFocus(final Interactable fromThis) {
+        final Component component = getComponent();
+
+        if (fromThis == null && component instanceof Interactable) {
+            return (Interactable) component;
+        }
+        else if (component instanceof Container) {
+            return ((Container) component).nextFocus(fromThis);
+        }
+
+        return null;
+    }
+
+    @Override
+    public Interactable previousFocus(final Interactable fromThis) {
+        final Component component = getComponent();
+
+        if (fromThis == null && component instanceof Interactable) {
+            return (Interactable) component;
+        }
+        else if (component instanceof Container) {
+            return ((Container) component).previousFocus(fromThis);
+        }
+
+        return null;
+    }
+
+    private boolean scrollInDirection(final KeyStroke key) {
+        final boolean isControlDown = key.isCtrlDown();
+        final boolean isAltDown = key.isAltDown();
+
+        if (isAltDown) {
+            return false;
+        }
+
+        // @formatter:off
+        switch (key.getKeyType()) {
+            default:            return false;
+
+            case ArrowLeft:     lineLeft();     break;
+            case ArrowRight:    lineRight();    break;
+            case ArrowUp:       lineUp();       break;
+            case ArrowDown:     lineDown();     break;
+            case PageUp:        pageUp();       break;
+            case PageDown:      pageDown();     break;
+
+            case Home:
+                if (isControlDown) {
+                    scrollToTop();
+                }
+                else {
+                    scrollToLeftEnd();
+                }
+                break;
+
+            case End:
+                if (isControlDown) {
+                    scrollToBottom();
+                }
+                else {
+                    scrollToRightEnd();
+                }
+                break;
+
+        }
+        // @formatter:on
+
+        return true;
+    }
+
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Scroll Operations">
+
+    public void lineUp() {
+        enqueueCommand(CommandCode.LINE_UP);
+    }
+
+    public void lineDown() {
+        enqueueCommand(CommandCode.LINE_DOWN);
+    }
+
+    public void lineLeft() {
+        enqueueCommand(CommandCode.LINE_LEFT);
+    }
+
+    public void lineRight() {
+        enqueueCommand(CommandCode.LINE_RIGHT);
+    }
+
+    public void pageUp() {
+        enqueueCommand(CommandCode.PAGE_UP);
+    }
+
+    public void pageDown() {
+        enqueueCommand(CommandCode.PAGE_DOWN);
+    }
+
+    public void pageLeft() {
+        enqueueCommand(CommandCode.PAGE_LEFT);
+    }
+
+    public void pageRight() {
+        enqueueCommand(CommandCode.PAGE_RIGHT);
+    }
+
+    public void scrollToLeftEnd() {
+        enqueueCommand(CommandCode.SET_OFFSET_H, -Scrollable.INFINITY);
+    }
+
+    public void scrollToRightEnd() {
+        enqueueCommand(CommandCode.SET_OFFSET_H, Scrollable.INFINITY);
+    }
+
+    public void scrollToHome() {
+        enqueueCommand(CommandCode.SET_OFFSET_H, -Scrollable.INFINITY);
+        enqueueCommand(CommandCode.SET_OFFSET_V, -Scrollable.INFINITY);
+    }
+
+    public void scrollToEnd() {
+        enqueueCommand(CommandCode.SET_OFFSET_H, Scrollable.INFINITY);
+        enqueueCommand(CommandCode.SET_OFFSET_V, Scrollable.INFINITY);
+    }
+
+    public void scrollToTop() {
+        enqueueCommand(CommandCode.SET_OFFSET_V, -Scrollable.INFINITY);
+    }
+
+    public void scrollToBottom() {
+        enqueueCommand(CommandCode.SET_OFFSET_V, Scrollable.INFINITY);
+    }
+
+    public void scrollToHorizontalOffset(final int offset) {
+        enqueueCommand(CommandCode.SET_OFFSET_H, validateInputOffset(offset));
+    }
+
+    public void scrollToVerticalOffset(final int offset) {
+        enqueueCommand(CommandCode.SET_OFFSET_V, validateInputOffset(offset));
+    }
+
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Properties">
+
+    public boolean getCanContentControlScrolling() {
+        return contentAdapter.getCanContentControlScrolling();
+    }
+
+    public void setCanContentControlScrolling(final boolean value) {
+        contentAdapter.setCanContentControlScrolling(value);
+    }
+
+    public ScrollBarPolicy getHorizontalScrollBarPolicy() {
+        return horizontalScrollBarPolicy;
+    }
+
+    public void setHorizontalScrollBarPolicy(final ScrollBarPolicy policy) {
+        horizontalScrollBarPolicy = policy;
+        invalidate();
+    }
+
+    public ScrollBarPolicy getVerticalScrollBarPolicy() {
+        return verticalScrollBarPolicy;
+    }
+
+    public void setVerticalScrollBarPolicy(final ScrollBarPolicy policy) {
+        verticalScrollBarPolicy = policy;
+        invalidate();
+    }
+
+    public boolean isHorizontalScrollingEnabled() {
+        return computedHorizontalScrollingEnabled;
+    }
+
+    public boolean isVerticalScrollingEnabled() {
+        return computedVerticalScrollingEnabled;
+    }
+
+    public int getVerticalOffset() {
+        return cachedVerticalOffset;
+    }
+
+    public void setVerticalOffset(final int offset) {
+        enqueueCommand(CommandCode.SET_OFFSET_V, offset);
+    }
+
+    public int getHorizontalOffset() {
+        return cachedHorizontalOffset;
+    }
+
+    public void setHorizontalOffset(final int offset) {
+        enqueueCommand(CommandCode.SET_OFFSET_H, offset);
+    }
+
+    public int getViewportWidth() {
+        return cachedViewportWidth;
+    }
+
+    public int getViewportHeight() {
+        return cachedViewportHeight;
+    }
+
+    public int getExtentWidth() {
+        return cachedExtentWidth;
+    }
+
+    public int getExtentHeight() {
+        return cachedExtentHeight;
+    }
+
+    public int getScrollableWidth() {
+        return max(0, getExtentWidth() - getViewportWidth());
+    }
+
+    public int getScrollableHeight() {
+        return max(0, getExtentHeight() - getViewportHeight());
+    }
+
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Component Overrides">
+
+    @Override
+    public synchronized void onAdded(final Container container) {
+        super.onAdded(container);
+
+        if (isLayoutUpdaterRequired) {
+            ensureProcessing();
+        }
+    }
+
+    @Override
+    public synchronized void onRemoved(final Container container) {
+        cancelLayoutUpdater();
+        renderer = null;
+        super.onRemoved(container);
+    }
+
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="ScrollOwner Implementation">
+
+    @Override
+    public void invalidateScrollInfo() {
+        final Scrollable s = scrollController;
+
+        if (s == null) {
+            return;
+        }
+
+        if (!isLayoutInProgress && (!isRenderInProgress || !isLayoutInvalidatedFromRender)) {
+            //
+            // Check if we should remove/add scrollbars.
+            //
+
+            int extent = s.getExtentWidth();
+            int viewport = s.getViewportWidth();
+
+            if (horizontalScrollBarPolicy == ScrollBarPolicy.AUTO &&
+                (extent > viewport && !computedHorizontalScrollingEnabled ||
+                 extent <= viewport && computedHorizontalScrollingEnabled)) {
+
+                invalidate();
+            }
+            else {
+                extent = s.getExtentHeight();
+                viewport = s.getViewportHeight();
+
+                if (verticalScrollBarPolicy == ScrollBarPolicy.AUTO &&
+                    (extent > viewport && !computedVerticalScrollingEnabled ||
+                     computedVerticalScrollingEnabled && viewport >= extent)) {
+
+                    invalidate();
+                }
+            }
+        }
+
+        //
+        // If any scrolling properties have actually changed, fire public events post-render.
+        //
+
+        if (getHorizontalOffset() != s.getHorizontalOffset() ||
+            getVerticalOffset() != s.getVerticalOffset() ||
+            getViewportWidth() != s.getViewportWidth() ||
+            getViewportHeight() != s.getViewportHeight() ||
+            getExtentWidth() != s.getExtentWidth() ||
+            getExtentHeight() != s.getExtentHeight()) {
+
+            ensureLayoutUpdater();
+        }
+    }
+
+    @Override
+    public void setScrollController(final Scrollable controller) {
+        scrollController = controller;
+
+        if (controller != null) {
+            controller.setHorizontalScrollingEnabled(horizontalScrollBarPolicy != ScrollBarPolicy.DISABLED);
+            controller.setVerticalScrollingEnabled(verticalScrollBarPolicy != ScrollBarPolicy.DISABLED);
+            ensureLayoutUpdater();
+        }
+    }
+
+    public Scrollable getScrollController() {
+        return scrollController;
+    }
+
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Layout">
+
+    private TerminalSize desiredSize;
+
+    private boolean isLayoutInProgress;
+    private boolean isLayoutInvalidatedFromRender;
+    private boolean isRenderInProgress;
+
+    private final static int VISIBLE_CHILD = 0x01;
+    private final static int VISIBLE_V_BAR = 0x02;
+    private final static int VISIBLE_H_BAR = 0x04;
+
+    @Override
+    public void invalidate() {
+        desiredSize = null;
+
+        if (isRenderInProgress) {
+            isLayoutInvalidatedFromRender = true;
+        }
+
+        setPreferredSize(null);
+//        setSize(null);
+
+        super.invalidate();
+    }
+
+    private void clearCachedLayout() {
+        computedHorizontalScrollingEnabled = false;
+        computedVerticalScrollingEnabled = false;
+        cachedHorizontalOffset = 0;
+        cachedVerticalOffset = 0;
+        cachedExtentHeight = 0;
+        cachedExtentWidth = 0;
+        cachedViewportWidth = 0;
+        cachedViewportHeight = 0;
+    }
+
+    private void updateLayout() {
+        if (executeNextCommand()) {
+            invalidate();
+            return;
+        }
+
+        final int oldActualHorizontalOffset = getHorizontalOffset();
+        final int oldActualVerticalOffset = getVerticalOffset();
+
+        final int oldViewportWidth = getViewportWidth();
+        final int oldViewportHeight = getViewportHeight();
+
+        final int oldExtentWidth = getExtentWidth();
+        final int oldExtentHeight = getExtentHeight();
+
+        final int oldScrollableWidth = getScrollableWidth();
+        final int oldScrollableHeight = getScrollableHeight();
+
+        boolean changed = false;
+
+        final Scrollable s = getScrollController();
+
+        // Go through scrolling properties and update any inconsistent values.
+
+        if (s != null && oldActualHorizontalOffset != s.getHorizontalOffset()) {
+            cachedHorizontalOffset = s.getHorizontalOffset();
+            changed = true;
+        }
+
+        if (s != null && oldActualVerticalOffset != s.getVerticalOffset()) {
+            cachedVerticalOffset = s.getVerticalOffset();
+            changed = true;
+        }
+
+        if (s != null && oldViewportWidth != s.getViewportWidth()) {
+            cachedViewportWidth = s.getViewportWidth();
+            changed = true;
+        }
+
+        if (s != null && oldViewportHeight != s.getViewportHeight()) {
+            cachedViewportHeight = s.getViewportHeight();
+            changed = true;
+        }
+
+        if (s != null && oldExtentWidth != s.getExtentWidth()) {
+            cachedExtentWidth = s.getExtentWidth();
+            changed = true;
+        }
+
+        if (s != null && oldExtentHeight != s.getExtentHeight()) {
+            cachedExtentHeight = s.getExtentHeight();
+            changed = true;
+        }
+
+        changed |= getScrollableWidth() != oldScrollableWidth ||
+                   getScrollableHeight() != oldScrollableHeight;
+
+        if (changed) {
+            try {
+                onScrollChanged();
+                return;
+            }
+            finally {
+                cancelLayoutUpdater();
+            }
+        }
+
+        cancelLayoutUpdater();
+    }
+
+    private final static class DeferredLayoutUpdater implements Runnable {
+        ScrollViewer owner;
+
+        @Override
+        public void run() {
+            final ScrollViewer sv = owner;
+
+            if (sv == null) {
+                return;
+            }
+
+            sv.isLayoutUpdaterScheduled = false;
+
+            try {
+                sv.updateLayout();
+            }
+            finally {
+                if (sv.isLayoutUpdaterRequired) {
+                    sv.ensureLayoutUpdater();
+                }
+            }
+        }
+    }
+
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="CommandCode & Command Queue">
+
+    private TextGUIThread updaterThread;
+    private CommandQueue queue;
+    private DeferredLayoutUpdater layoutUpdater;
+    private boolean isLayoutUpdaterRequired;
+    private boolean isLayoutUpdaterScheduled;
+
+    private void enqueueCommand(final CommandCode code) {
+        enqueueCommand(code, 0);
+    }
+
+    private void enqueueCommand(final CommandCode code, final int parameter) {
+        ensureQueue().enqueue(code, parameter);
+        ensureLayoutUpdater();
+    }
+
+    private CommandQueue ensureQueue() {
+        final CommandQueue queue = this.queue;
+        return queue != null ? queue : (this.queue = new CommandQueue());
+    }
+
+    private void ensureProcessing() {
+        final CommandQueue queue = this.queue;
+
+        if (queue != null && !queue.isEmpty()) {
+            ensureLayoutUpdater();
+        }
+    }
+
+    private TextGUIThread ensureUpdaterThread() {
+        final TextGUIThread updaterThread = this.updaterThread;
+
+        if (updaterThread != null) {
+            return updaterThread;
+        }
+
+        final TextGUI textGUI = getTextGUI();
+
+        if (textGUI == null) {
+            return null;
+        }
+
+        return this.updaterThread = textGUI.getGUIThread();
+    }
+
+    private void cancelLayoutUpdater() {
+        final DeferredLayoutUpdater u = layoutUpdater;
+
+        if (u != null) {
+            u.owner = null;
+        }
+
+        updaterThread = null;
+        layoutUpdater = null;
+        isLayoutUpdaterRequired = false;
+        isLayoutUpdaterScheduled = false;
+    }
+
+    private void ensureLayoutUpdater() {
+        isLayoutUpdaterRequired = true;
+
+        if (isLayoutUpdaterScheduled) {
+            return;
+        }
+
+        final TextGUIThread guiThread = ensureUpdaterThread();
+
+        if (guiThread == null) {
+            return;
+        }
+
+        DeferredLayoutUpdater queueProcessor = this.layoutUpdater;
+
+        if (queueProcessor == null) {
+            queueProcessor = new DeferredLayoutUpdater();
+            this.layoutUpdater = queueProcessor;
+        }
+
+        queueProcessor.owner = this;
+        guiThread.invokeLater(queueProcessor);
+        isLayoutUpdaterScheduled = true;
+    }
+
+    private enum CommandCode {
+        INVALID,
+        LINE_UP,
+        LINE_DOWN,
+        LINE_LEFT,
+        LINE_RIGHT,
+        PAGE_UP,
+        PAGE_DOWN,
+        PAGE_LEFT,
+        PAGE_RIGHT,
+        SET_OFFSET_H,
+        SET_OFFSET_V
+    }
+
+    private final static class Command {
+        final static Command INVALID = new Command(CommandCode.INVALID, 0);
+
+        CommandCode code;
+        int parameter;
+
+        Command(final CommandCode code, final int parameter) {
+            this.code = code;
+            this.parameter = parameter;
+        }
+    }
+
+    private final static class CommandQueue {
+        private static final int CAPACITY = 32;
+
+        private final Command[] array;
+
+        private int lastWritePosition;
+        private int lastReadPosition;
+
+        CommandQueue() {
+            array = new Command[CAPACITY];
+
+            for (int i = 0; i < array.length; i++) {
+                array[i] = new Command(CommandCode.INVALID, 0);
+            }
+        }
+
+        final void enqueue(final CommandCode code) {
+            enqueue(code, 0);
+        }
+
+        final void enqueue(final CommandCode code, final int parameter) {
+            if (!optimizeCommand(code, parameter)) {
+                final int newWritePosition = (lastWritePosition + 1) % CAPACITY;
+
+                if (newWritePosition == lastReadPosition) {
+                    lastReadPosition = (lastReadPosition + 1) % CAPACITY;
+                }
+
+                final Command command = array[newWritePosition];
+
+                command.code = code;
+                command.parameter = parameter;
+
+                lastWritePosition = newWritePosition;
+            }
+        }
+
+        final boolean optimizeCommand(final CommandCode code, final int parameter) {
+            if (lastWritePosition != lastReadPosition) {
+                if ((code == CommandCode.SET_OFFSET_H &&
+                     array[lastWritePosition].code == CommandCode.SET_OFFSET_H) ||
+                    (code == CommandCode.SET_OFFSET_V &&
+                     array[lastWritePosition].code == CommandCode.SET_OFFSET_V)) {
+
+                    // If the last command was "set offset" or "make visible", simply replace it.
+                    array[lastWritePosition].parameter = parameter;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        final Command fetch() {
+            if (lastWritePosition == lastReadPosition) {
+                return Command.INVALID;
+            }
+
+            lastReadPosition = (lastReadPosition + 1) % CAPACITY;
+
+            return array[lastReadPosition];
+        }
+
+        final boolean isEmpty() {
+            return lastWritePosition == lastReadPosition;
+        }
+    }
+
+    final boolean executeNextCommand() {
+        final Scrollable s = this.scrollController;
+
+        if (s == null) {
+            return false;
+        }
+
+        final CommandQueue q = queue;
+        final Command c = q != null ? q.fetch() : Command.INVALID;
+
+        if (c.code == CommandCode.INVALID) {
+            return false;
+        }
+
+        // @formatter:off
+        switch (c.code) {
+            case LINE_UP:       s.lineUp();                         break;
+            case LINE_DOWN:     s.lineDown();                       break;
+            case LINE_LEFT:     s.lineLeft();                       break;
+            case LINE_RIGHT:    s.lineRight();                      break;
+            case PAGE_UP:       s.pageUp();                         break;
+            case PAGE_DOWN:     s.pageDown();                       break;
+            case PAGE_LEFT:     s.pageLeft();                       break;
+            case PAGE_RIGHT:    s.pageRight();                      break;
+
+            case SET_OFFSET_H:  s.setHorizontalOffset(c.parameter); break;
+            case SET_OFFSET_V:  s.setVerticalOffset(c.parameter);   break;
+        }
+        // @formatter:on
+
+        return true;
+    }
+
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Renderer">
+
+    //
+    // NOTE: ScrollViewer has no look of its own; it's just a viewport with a pair of scrollbars.
+    //       Since the default renderer is responsible for complex layout, we expressly prohibit
+    //       specifying a different renderer.
+    //
+
+    @Override
+    public final synchronized ComponentRenderer<ScrollViewer> getRenderer() {
+        ComponentRenderer<ScrollViewer> renderer = this.renderer;
+
+        if (renderer == null) {
+            this.renderer = renderer = createDefaultRenderer();
+        }
+
+        return renderer;
+    }
+
+    @Override
+    public final ScrollViewer setRenderer(final ComponentRenderer<ScrollViewer> renderer) {
+        throw new UnsupportedOperationException("ScrollViewer does not support custom renderers.");
+    }
+
+    @Override
+    protected final ComponentRenderer<ScrollViewer> createDefaultRenderer() {
+        return new ScrollViewerRenderer();
+    }
+
+    private final static class ScrollViewerRenderer implements ComponentRenderer<ScrollViewer> {
+        private TerminalSize totalSize;
+        private TerminalSize desiredChildSize;
+        private TerminalSize hBarSize;
+        private TerminalSize vBarSize;
+
+        @Override
+        public TerminalSize getPreferredSize(final ScrollViewer sv) {
+            final boolean wasLayoutInProgress = sv.isLayoutInProgress;
+
+            TerminalSize desiredSize = TerminalSize.ZERO;
+
+            sv.isLayoutInProgress = true;
+
+            try {
+                final Component child = sv.component;
+
+                if (child != null) {
+                    child.setPreferredSize(null);
+                    desiredChildSize = desiredSize = child.getPreferredSize();
+                    child.setPreferredSize(desiredSize);
+                }
+
+                if (sv.computedVerticalScrollingEnabled) {
+                    vBarSize = sv.verticalScrollBar.getPreferredSize();
+                    desiredSize = desiredSize.withColumns(desiredSize.getColumns() + vBarSize.getColumns());
+                }
+                else {
+                    vBarSize = TerminalSize.ZERO;
+                }
+
+                if (sv.computedHorizontalScrollingEnabled) {
+                    hBarSize = sv.horizontalScrollBar.getPreferredSize();
+                    desiredSize = desiredSize.withRows(desiredSize.getRows() + hBarSize.getColumns());
+                }
+                else {
+                    hBarSize = TerminalSize.ZERO;
+                }
+            }
+            finally {
+                sv.isLayoutInProgress = wasLayoutInProgress;
+            }
+
+            totalSize = desiredSize;
+
+            return desiredSize;
+        }
+
+        @Override
+        public void drawComponent(final TextGUIGraphics g, final ScrollViewer sv) {
+            final boolean wasRenderInProgress = sv.isRenderInProgress;
+
+            sv.isRenderInProgress = true;
+
+            try {
+                final TerminalSize size = g.getSize();
+                final Component child = sv.component;
+
+                sv.setSize(size);
+
+                final boolean hv = computeHorizontalScrolling(sv);
+                final boolean vv = computeVerticalScrolling(sv);
+
+                if (hv != sv.computedHorizontalScrollingEnabled ||
+                    vv != sv.computedVerticalScrollingEnabled) {
+
+                    sv.computedHorizontalScrollingEnabled = hv;
+                    sv.computedVerticalScrollingEnabled = vv;
+
+                    if (!sv.isLayoutInvalidatedFromRender) {
+                        sv.invalidate();
+                    }
+                }
+
+                if (child != null) {
+                    final int dX = vv ? -vBarSize.getColumns() - 1 : 0;
+                    final int dY = hv ? -hBarSize.getRows() : 0;
+
+                    sv.contentAdapter.draw(
+                        g.newTextGraphics(
+                            TerminalPosition.TOP_LEFT_CORNER,
+                            size.withRelative(dX, dY)
+                        ),
+                        desiredChildSize
+                    );
+                }
+
+                sv.updateLayout();
+
+                sv.horizontalScrollBar.setViewSize(sv.getViewportWidth());
+                sv.horizontalScrollBar.setScrollMaximum(sv.getExtentWidth());
+                sv.horizontalScrollBar.setScrollPosition(sv.getHorizontalOffset());
+
+                sv.verticalScrollBar.setViewSize(sv.getViewportHeight());
+                sv.verticalScrollBar.setScrollMaximum(sv.getExtentHeight());
+                sv.verticalScrollBar.setScrollPosition(sv.getVerticalOffset());
+
+                if (hv) {
+                    if (sv.horizontalScrollBar.getParent() != sv) {
+                        sv.horizontalScrollBar.onAdded(sv);
+                    }
+
+                    final TerminalPosition hPosition = new TerminalPosition(
+                        1,
+                        size.getRows() - hBarSize.getRows()
+                    );
+
+                    sv.horizontalScrollBar.setPosition(hPosition);
+
+                    sv.horizontalScrollBar.draw(
+                        g.newTextGraphics(
+                            hPosition.withRelativeColumn(-1),
+                            new TerminalSize(size.getColumns() - 1, hBarSize.getRows())
+                        )
+                    );
+                }
+                else {
+                    if (sv.horizontalScrollBar.getParent() == sv) {
+                        sv.horizontalScrollBar.onRemoved(sv);
+                    }
+                }
+
+                if (vv) {
+                    if (sv.verticalScrollBar.getParent() != sv) {
+                        sv.verticalScrollBar.onAdded(sv);
+                    }
+
+                    final TerminalPosition vPosition = new TerminalPosition(
+                        size.getColumns() - vBarSize.getColumns() ,
+                        1
+                    );
+
+                    sv.verticalScrollBar.setPosition(vPosition);
+
+                    sv.verticalScrollBar.draw(
+                        g.newTextGraphics(
+                            vPosition.withRelativeRow(-1),
+                            new TerminalSize(vBarSize.getColumns(), size.getRows() - 1)
+                        )
+                    );
+                }
+                else {
+                    if (sv.verticalScrollBar.getParent() == sv) {
+                        sv.verticalScrollBar.onRemoved(sv);
+                    }
+                }
+            }
+            finally {
+                sv.isRenderInProgress = wasRenderInProgress;
+            }
+        }
+
+        private boolean computeHorizontalScrolling(final ScrollViewer sv) {
+            //noinspection SimplifiableIfStatement
+            if (sv.horizontalScrollBarPolicy == ScrollBarPolicy.VISIBLE) {
+                return true;
+            }
+
+            return sv.horizontalScrollBarPolicy == ScrollBarPolicy.AUTO &&
+                   desiredChildSize.getColumns() > sv.getSize().getColumns() - vBarSize.getColumns();
+        }
+
+        private boolean computeVerticalScrolling(final ScrollViewer sv) {
+            //noinspection SimplifiableIfStatement
+            if (sv.verticalScrollBarPolicy == ScrollBarPolicy.VISIBLE) {
+                return true;
+            }
+
+            return sv.verticalScrollBarPolicy == ScrollBarPolicy.AUTO &&
+                   desiredChildSize.getRows() > sv.getSize().getRows() - hBarSize.getRows();
+        }
+    }
+
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Listener">
+
+    private final List<Listener> listeners = new CopyOnWriteArrayList<Listener>();
+
+    protected synchronized void onScrollChanged() {
+        for (final Listener listener : listeners) {
+            listener.onScrollChanged(this);
+        }
+    }
+
+    public interface Listener {
+        void onScrollChanged(ScrollViewer sv);
+    }
+
+    public void addListener(final Listener listener) {
+        if (listener == null) {
+            throw new IllegalArgumentException("Listener cannot be null.");
+        }
+        listeners.add(listener);
+    }
+
+    public boolean removeListener(final Listener listener) {
+        return listeners.remove(listener);
+    }
+
+    // </editor-fold>
+
+//    // <editor-fold defaultstate="collapsed" desc="Interactable Implementation">
+//
+//    boolean ifFocused;
+//    boolean isEnabled;
+//
+//    @Override
+//    public TerminalPosition getCursorLocation() {
+//        return null;
+//    }
+//
+//    @Override
+//    public Interactable takeFocus() {
+//        if(!isEnabled()) {
+//            return self();
+//        }
+//
+//        final BasePane basePane = getBasePane();
+//
+//        if(basePane != null) {
+//            basePane.setFocusedInteractable(this);
+//        }
+//
+//        return self();
+//    }
+//
+//    @Override
+//    public void onEnterFocus(FocusChangeDirection direction, Interactable previouslyInFocus) {
+//        ifFocused = true;
+//    }
+//
+//    @Override
+//    public void onLeaveFocus(FocusChangeDirection direction, Interactable nextInFocus) {
+//        ifFocused = false;
+//    }
+//
+//    @Override
+//    public boolean isFocused() {
+//        return ifFocused;
+//    }
+//
+//    @Override
+//    public Interactable setInputFilter(InputFilter inputFilter) {
+//        return this;
+//    }
+//
+//    @Override
+//    public InputFilter getInputFilter() {
+//        return null;
+//    }
+//
+//    @Override
+//    public Interactable setEnabled(boolean enabled) {
+//        isEnabled = enabled;
+//
+//        if (!enabled && isFocused()) {
+//            final BasePane basePane = getBasePane();
+//
+//            if (basePane != null) {
+//                basePane.setFocusedInteractable(null);
+//            }
+//        }
+//
+//        return self();
+//    }
+//
+//    @Override
+//    public boolean isEnabled() {
+//        return isEnabled;
+//    }
+//
+//    @Override
+//    public boolean isFocusable() {
+//        return false;
+//    }
+//
+//    // </editor-fold>
+}

--- a/src/main/java/com/googlecode/lanterna/gui2/ScrollViewer.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/ScrollViewer.java
@@ -164,8 +164,8 @@ public class ScrollViewer
         if (component instanceof Container) {
             ((Container) getComponent()).updateLookupMap(map);
         }
-        else if (getComponent() instanceof Interactable) {
-            map.add((Interactable) getComponent());
+        else if (component instanceof Interactable) {
+            map.add((Interactable) component);
         }
     }
 
@@ -572,7 +572,7 @@ public class ScrollViewer
             isLayoutInvalidatedFromRender = true;
         }
 
-        setPreferredSize(null);
+//        setPreferredSize(null);
 
         super.invalidate();
     }

--- a/src/main/java/com/googlecode/lanterna/gui2/Scrollable.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/Scrollable.java
@@ -1,0 +1,35 @@
+package com.googlecode.lanterna.gui2;
+
+public interface Scrollable {
+    int INFINITY = Integer.MAX_VALUE;
+
+    void lineUp();
+    void lineDown();
+    void lineLeft();
+    void lineRight();
+
+    void pageUp();
+    void pageDown();
+    void pageLeft();
+    void pageRight();
+
+    int getHorizontalOffset();
+    void setHorizontalOffset(int offset);
+
+    int getVerticalOffset();
+    void setVerticalOffset(int offset);
+
+    boolean isVerticalScrollingEnabled();
+    void setVerticalScrollingEnabled(boolean value);
+
+    boolean isHorizontalScrollingEnabled();
+    void setHorizontalScrollingEnabled(boolean value);
+
+    int getViewportWidth();
+    int getViewportHeight();
+    int getExtentWidth();
+    int getExtentHeight();
+
+    ScrollOwner getScrollOwner();
+    void setScrollOwner(ScrollOwner owner);
+}

--- a/src/main/java/com/googlecode/lanterna/gui2/ScrollableContentAdapter.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/ScrollableContentAdapter.java
@@ -193,14 +193,13 @@ final class ScrollableContentAdapter implements ScrollController {
             return Rectangle.EMPTY;
         }
 
-        final Container parent = component.getParent();
         final ScrollViewer sv = getScrollOwner();
 
         if (sv == null) {
             return Rectangle.EMPTY;
         }
 
-        final TerminalPosition relativeOffset = component.toAncestor(parent, TerminalPosition.TOP_LEFT_CORNER);
+        final TerminalPosition relativeOffset = component.toAncestor(sv, TerminalPosition.TOP_LEFT_CORNER);
 
         Rectangle rectangle = targetRectangle;
 
@@ -221,7 +220,7 @@ final class ScrollableContentAdapter implements ScrollController {
             getViewportHeight()
         );
 
-        rectangle.offset(viewport.getPosition());
+        rectangle = rectangle.offset(viewport.getPosition());
 
         //
         // Compute the offsets required to minimally scroll the child maximally into view:
@@ -356,7 +355,7 @@ final class ScrollableContentAdapter implements ScrollController {
 
         final ScrollData d = scrollData;
 
-        component.setPosition(d.componentPosition);
+        component.setPosition(d.graphicsOffset);
         component.draw(g.newTextGraphics(d.graphicsOffset, d.graphicsSize));
     }
 
@@ -397,12 +396,10 @@ final class ScrollableContentAdapter implements ScrollController {
         if (isScrollClient()) {
             d.graphicsOffset = new TerminalPosition(-d.computedHorizontalOffset, -d.computedVerticalOffset);
             d.graphicsSize = new TerminalSize(d.extentWidth, d.extentHeight);
-            d.componentPosition = d.graphicsOffset.withRelative(1, 1);
         }
         else {
             d.graphicsOffset = TerminalPosition.TOP_LEFT_CORNER;
             d.graphicsSize = d.viewport;
-            d.componentPosition = TerminalPosition.OFFSET_1x1;
         }
 
         if (!valid) {
@@ -479,8 +476,6 @@ final class ScrollableContentAdapter implements ScrollController {
 
         TerminalSize viewport;
         TerminalPosition offset;
-
-        TerminalPosition componentPosition;
 
         TerminalPosition graphicsOffset;
         TerminalSize graphicsSize;

--- a/src/main/java/com/googlecode/lanterna/gui2/ScrollableContentAdapter.java
+++ b/src/main/java/com/googlecode/lanterna/gui2/ScrollableContentAdapter.java
@@ -1,0 +1,365 @@
+package com.googlecode.lanterna.gui2;
+
+import com.googlecode.lanterna.TerminalPosition;
+import com.googlecode.lanterna.TerminalSize;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+final class ScrollableContentAdapter implements Scrollable {
+    private Component adaptedComponent;
+    private Scrollable scrollController;
+    private ScrollData scrollData;
+    private boolean canContentControlScrolling;
+
+    public void setAdaptedComponent(final Component component) {
+        adaptedComponent = component;
+        connectScrollableComponent();
+    }
+
+    private void invalidate() {
+        final Component component = adaptedComponent;
+        final Component container = component != null ? component.getParent() : null;
+
+        if (container != null) {
+            container.invalidate();
+        }
+    }
+
+    public boolean getCanContentControlScrolling() {
+        return canContentControlScrolling;
+    }
+
+    public void setCanContentControlScrolling(final boolean value) {
+        if (value == canContentControlScrolling) {
+            return;
+        }
+
+        canContentControlScrolling = value;
+
+        if (scrollController == null) {
+            return;
+        }
+
+        connectScrollableComponent();
+    }
+
+    @Override
+    public void lineUp() {
+        setVerticalOffset(getVerticalOffset() - 1);
+    }
+
+    @Override
+    public void lineDown() {
+        setVerticalOffset(getVerticalOffset() + 1);
+    }
+
+    @Override
+    public void lineLeft() {
+        setHorizontalOffset(getHorizontalOffset() - 1);
+    }
+
+    @Override
+    public void lineRight() {
+        setHorizontalOffset(getHorizontalOffset() + 1);
+    }
+
+    @Override
+    public void pageUp() {
+        setVerticalOffset(getVerticalOffset() - getViewportHeight());
+    }
+
+    @Override
+    public void pageDown() {
+        setVerticalOffset(getVerticalOffset() + getViewportHeight());
+    }
+
+    @Override
+    public void pageLeft() {
+        setHorizontalOffset(getHorizontalOffset() - getViewportWidth());
+    }
+
+    @Override
+    public void pageRight() {
+        setHorizontalOffset(getHorizontalOffset() + getViewportWidth());
+    }
+
+    @Override
+    public int getHorizontalOffset() {
+        return isScrollClient() ? ensureScrollData().computedHorizontalOffset : 0;
+    }
+
+    @Override
+    public void setHorizontalOffset(final int offset) {
+        if (isScrollClient()) {
+            final int newOffset = validateInputOffset(offset);
+            if (newOffset != ensureScrollData().horizontalOffset) {
+                scrollData.horizontalOffset = newOffset;
+                invalidate();
+            }
+        }
+    }
+
+    @Override
+    public int getVerticalOffset() {
+        return isScrollClient() ? ensureScrollData().computedVerticalOffset : 0;
+    }
+
+    @Override
+    public void setVerticalOffset(final int offset) {
+        if (isScrollClient()) {
+            final int newOffset = validateInputOffset(offset);
+            if (newOffset != ensureScrollData().verticalOffset) {
+                scrollData.verticalOffset = newOffset;
+                invalidate();
+            }
+        }
+    }
+
+    @Override
+    public boolean isVerticalScrollingEnabled() {
+        return isScrollClient() && ensureScrollData().canVerticallyScroll;
+    }
+
+    @Override
+    public void setVerticalScrollingEnabled(final boolean value) {
+        if (isScrollClient()) {
+            if (value != ensureScrollData().canVerticallyScroll) {
+                scrollData.canVerticallyScroll = true;
+                invalidate();
+            }
+        }
+    }
+
+    @Override
+    public boolean isHorizontalScrollingEnabled() {
+        return isScrollClient() && ensureScrollData().canHorizontallyScroll;
+    }
+
+    @Override
+    public void setHorizontalScrollingEnabled(final boolean value) {
+        if (isScrollClient()) {
+            if (value != ensureScrollData().canHorizontallyScroll) {
+                scrollData.canHorizontallyScroll = true;
+                invalidate();
+            }
+        }
+    }
+
+    @Override
+    public int getViewportWidth() {
+        return isScrollClient() ? ensureScrollData().viewportWidth : 0;
+    }
+
+    @Override
+    public int getViewportHeight() {
+        return isScrollClient() ? ensureScrollData().viewportHeight : 0;
+    }
+
+    @Override
+    public int getExtentWidth() {
+        return isScrollClient() ? ensureScrollData().extentWidth : 0;
+    }
+
+    @Override
+    public int getExtentHeight() {
+        return isScrollClient() ? ensureScrollData().extentHeight : 0;
+    }
+
+    @Override
+    public ScrollOwner getScrollOwner() {
+        return isScrollClient() ? ensureScrollData().scrollOwner : null;
+    }
+
+    @Override
+    public void setScrollOwner(final ScrollOwner owner) {
+        if (isScrollClient()) {
+            ensureScrollData().scrollOwner = owner;
+        }
+    }
+
+    private ScrollData ensureScrollData() {
+        final ScrollData scrollData = this.scrollData;
+        return scrollData != null ? scrollData : (this.scrollData = new ScrollData());
+    }
+
+    private boolean isScrollClient() {
+        return scrollController == this;
+    }
+
+    private int coerceOffset(final int offset, final int extent, final int viewport) {
+        return max(0, min(offset, extent - viewport));
+    }
+
+    private boolean coerceOffsets() {
+        final ScrollData d = scrollData;
+
+        final int computedHorizontalOffset = coerceOffset(
+            d.horizontalOffset,
+            d.extentWidth,
+            d.viewportWidth
+        );
+
+        final int computedVerticalOffset = coerceOffset(
+            d.verticalOffset,
+            d.extentHeight,
+            d.viewportHeight
+        );
+
+        final boolean valid = d.computedHorizontalOffset == computedHorizontalOffset &&
+                              d.computedVerticalOffset == computedVerticalOffset;
+
+        d.computedHorizontalOffset = computedHorizontalOffset;
+        d.computedVerticalOffset = computedVerticalOffset;
+
+        if (d.offset == null ||
+            d.offset.getColumn() != d.computedHorizontalOffset ||
+            d.offset.getRow() != d.computedVerticalOffset) {
+
+            d.offset = new TerminalPosition(computedHorizontalOffset, computedVerticalOffset);
+        }
+
+        return valid;
+    }
+
+    static int validateInputOffset(final int offset) {
+        return max(0, offset);
+    }
+
+    final void draw(final TextGUIGraphics g, final TerminalSize extent) {
+        final Component component = this.adaptedComponent;
+
+        verifyScrollData(g.getSize(), extent);
+
+        final ScrollData d = scrollData;
+
+        component.setPosition(d.componentPosition);
+        component.draw(g.newTextGraphics(d.graphicsOffset, d.graphicsSize));
+    }
+
+    private void verifyScrollData(final TerminalSize viewport, final TerminalSize extent) {
+        final ScrollData d = this.scrollData;
+
+        boolean valid;
+
+        int coercedViewportWidth = viewport.getColumns();
+        int coercedViewportHeight = viewport.getRows();
+
+        if (coercedViewportWidth == INFINITY) {
+            coercedViewportWidth = extent.getColumns();
+        }
+
+        if (coercedViewportHeight == INFINITY) {
+            coercedViewportHeight = extent.getRows();
+        }
+
+        valid = coercedViewportWidth == d.viewportWidth &&
+                coercedViewportHeight == d.viewportHeight;
+
+        d.viewportWidth = coercedViewportWidth;
+        d.viewportHeight = coercedViewportHeight;
+
+        valid &= coerceOffsets();
+
+        if (d.viewport == null ||
+            d.viewport.getColumns() != coercedViewportWidth ||
+            d.viewport.getRows() != coercedViewportHeight) {
+
+            d.viewport = new TerminalSize(coercedViewportWidth, coercedViewportHeight);
+        }
+
+        d.extentWidth = extent.getColumns();
+        d.extentHeight = extent.getRows();
+
+        if (isScrollClient()) {
+            d.graphicsOffset = new TerminalPosition(-d.computedHorizontalOffset, -d.computedVerticalOffset);
+            d.graphicsSize = new TerminalSize(d.extentWidth, d.extentHeight);
+            d.componentPosition = d.graphicsOffset.withRelative(1, 1);
+        }
+        else {
+            d.graphicsOffset = TerminalPosition.TOP_LEFT_CORNER;
+            d.graphicsSize = d.viewport;
+            d.componentPosition = TerminalPosition.OFFSET_1x1;
+        }
+
+        if (!valid) {
+            d.scrollOwner.invalidateScrollInfo();
+        }
+    }
+
+    private void connectScrollableComponent() {
+        final Component component = adaptedComponent;
+        final Component container = component != null ? component.getParent() : null;
+
+        if (container instanceof ScrollViewer) {
+            final ScrollViewer scrollContainer = (ScrollViewer) container;
+
+            Scrollable s = null;
+
+            // If permitted, allow any scrollable content to control scrolling.
+            if (canContentControlScrolling && component instanceof Scrollable) {
+                s = (Scrollable) component;
+            }
+
+            // If content isn't controlling scrolling, we must control it ourselves.
+            if (s == null) {
+                s = this;
+                ensureScrollData();
+            }
+
+            // Detach any previous Scrollable from the ScrollViewer.
+            if (s != scrollController && scrollController != null) {
+                if (isScrollClient()) {
+                    scrollData = null;
+                }
+                else {
+                    scrollData.scrollOwner = null;
+                }
+            }
+
+            // Connect the ScrollViewer and the scroll controller to each other.
+            scrollController = s;
+            s.setScrollOwner(scrollContainer);
+            scrollContainer.setScrollController(scrollController);
+        }
+        else if (scrollController != null) {
+            // We're not in a valid scrolling scenario, so disconnect any existing
+            // links and get ourselves into a totally unlinked state.
+
+            final ScrollOwner oldScrollOwner = scrollController.getScrollOwner();
+
+            if (oldScrollOwner != null) {
+                oldScrollOwner.setScrollController(null);
+            }
+
+            scrollController.setScrollOwner(null);
+            scrollController = null;
+            scrollData = null;
+        }
+    }
+
+    private static final class ScrollData {
+        ScrollOwner scrollOwner;
+
+        boolean canHorizontallyScroll;
+        boolean canVerticallyScroll;
+
+        int viewportWidth;
+        int viewportHeight;
+        int extentWidth;
+        int extentHeight;
+        int horizontalOffset;
+        int verticalOffset;
+
+        int computedVerticalOffset;
+        int computedHorizontalOffset;
+
+        TerminalSize viewport;
+        TerminalPosition offset;
+
+        TerminalPosition componentPosition;
+
+        TerminalPosition graphicsOffset;
+        TerminalSize graphicsSize;
+    }
+}

--- a/src/test/java/com/googlecode/lanterna/gui2/ScrollControllerTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/ScrollControllerTest.java
@@ -1,0 +1,212 @@
+package com.googlecode.lanterna.gui2;
+
+import com.googlecode.lanterna.TerminalPosition;
+import com.googlecode.lanterna.TerminalSize;
+import com.googlecode.lanterna.TextCharacter;
+import com.googlecode.lanterna.TextColor;
+import com.googlecode.lanterna.input.KeyStroke;
+import com.googlecode.lanterna.input.KeyType;
+
+import java.io.IOException;
+
+import static java.lang.Math.min;
+
+public class ScrollControllerTest extends TestBase {
+    public static void main(final String[] args) throws IOException, InterruptedException {
+        new ScrollControllerTest().run(args);
+    }
+
+    @Override
+    public void init(final WindowBasedTextGUI textGUI) {
+        final BasicWindow cbWindow = new BasicWindow("Checkerboard as ScrollController");
+        final ScrollViewer sv = new ScrollViewer();
+
+        sv.setPreferredSize(new TerminalSize(Checkerboard.CELL_W * 6 + 2,
+                                             Checkerboard.CELL_H * 6 + 1));
+
+        sv.setComponent(new Checkerboard());
+
+        cbWindow.setComponent(
+            Panels.vertical(
+                sv,
+                new CheckBox("Let Content Control Scrolling").addListener(
+                    new CheckBox.Listener() {
+                        @Override
+                        public void onStatusChanged(final boolean checked) {
+                            final int offsetX = sv.getHorizontalOffset();
+                            final int offsetY = sv.getVerticalOffset();
+
+                            sv.setCanContentControlScrolling(checked);
+
+                            sv.setHorizontalOffset(offsetX);
+                            sv.setVerticalOffset(offsetY);
+                        }
+                    }
+                )
+            )
+        );
+
+        textGUI.addWindow(cbWindow);
+    }
+
+
+    private final static class Checkerboard extends AbstractScrollableComponent<Checkerboard> implements Interactable {
+        final static int DIM_XY = 20;
+        final static int CELL_W = 6;
+        final static int CELL_H = 2;
+
+        @Override
+        public void lineUp() {
+            setVerticalOffset(getVerticalOffset() - CELL_H + (getVerticalOffset() % CELL_H));
+        }
+
+        @Override
+        public void lineDown() {
+            setVerticalOffset(getVerticalOffset() + CELL_H - (getVerticalOffset() % CELL_H));
+        }
+
+        @Override
+        public void lineLeft() {
+            setHorizontalOffset(getHorizontalOffset() - CELL_W + (getHorizontalOffset() % CELL_W));
+        }
+
+        @Override
+        public void lineRight() {
+            setHorizontalOffset(getHorizontalOffset() + CELL_W - (getHorizontalOffset() % CELL_W));
+        }
+
+        @Override
+        protected ComponentRenderer<Checkerboard> createDefaultRenderer() {
+            return new ComponentRenderer<Checkerboard>() {
+                final TextColor BLACK = TextColor.Factory.fromString("#191919");
+                final TextColor WHITE = TextColor.ANSI.WHITE;
+
+                @Override
+                public TerminalSize getPreferredSize(final Checkerboard c) {
+                    return new TerminalSize(120, 40);
+                }
+
+                @Override
+                public void drawComponent(final TextGUIGraphics g, final Checkerboard c) {
+                    final int w = CELL_W * DIM_XY;
+                    final int h = CELL_H * DIM_XY;
+
+                    final boolean s = c.getScrollOwner() != null && c.getScrollOwner().getCanContentControlScrolling();
+
+                    final int xOffset = s ? getHorizontalOffset() : 0;
+                    final int yOffset = s ? getVerticalOffset() : 0;
+                    final int vWidth = s ? getViewportWidth() : getExtentWidth();
+                    final int vHeight = s ? getViewportHeight() : getExtentHeight();
+
+                    final int dX = -(xOffset % CELL_W);
+                    final int dY = -(yOffset % CELL_H);
+
+                    for (int x = xOffset, m = min(xOffset + vWidth, w) + xOffset % CELL_W; x <= m; x += CELL_W * 2) {
+                        final int col = x / CELL_W;
+                        final boolean shift = col % 2 != 0;
+
+                        for (int y = yOffset, n = min(yOffset + vHeight, h) + yOffset % CELL_H; y <= n; y+= CELL_H) {
+                            final int row = y / CELL_H;
+
+                            final TextColor bg1 = (row % 2 == 0) == shift ? BLACK : WHITE;
+                            final TextColor bg2 = (row % 2 == 0) == shift ? WHITE : BLACK;
+
+                            g.fillRectangle(
+                                new TerminalPosition(x + dX - xOffset, y + dY - yOffset),
+                                new TerminalSize(CELL_W, CELL_H),
+                                new TextCharacter(' ', WHITE, bg1)
+                            );
+                            g.fillRectangle(
+                                new TerminalPosition(x + CELL_W + dX - xOffset, y + dY - yOffset),
+                                new TerminalSize(CELL_W, CELL_H),
+                                new TextCharacter(' ', WHITE, bg2)
+                            );
+                        }
+                    }
+                }
+            };
+        }
+
+        @Override
+        public TerminalPosition getCursorLocation() {
+            return null;
+        }
+
+        @Override
+        public Result handleInput(final KeyStroke keyStroke) {
+            final boolean scrollable = getScrollOwner() != null;
+
+            // Skip the keystroke if ctrl, alt or shift was down
+            if(!keyStroke.isAltDown() && !keyStroke.isCtrlDown()) {
+                if(!keyStroke.isShiftDown()) {
+                    switch(keyStroke.getKeyType()) {
+                        case ArrowDown:
+                            return scrollable ? Result.UNHANDLED : Result.MOVE_FOCUS_DOWN;
+                        case ArrowLeft:
+                            return scrollable ? Result.UNHANDLED : Result.MOVE_FOCUS_LEFT;
+                        case ArrowRight:
+                            return scrollable ? Result.UNHANDLED : Result.MOVE_FOCUS_RIGHT;
+                        case ArrowUp:
+                            return scrollable ? Result.UNHANDLED : Result.MOVE_FOCUS_UP;
+                        case Tab:
+                            return Result.MOVE_FOCUS_NEXT;
+                        case ReverseTab:
+                            return Result.MOVE_FOCUS_PREVIOUS;
+                        case MouseEvent:
+                            getBasePane().setFocusedInteractable(this);
+                            return Result.HANDLED;
+                        default:
+                    }
+                }
+                // On Mac at least, Shift+Tab is ReverseTab, and isShiftDown() always reports `true`.
+                if (keyStroke.getKeyType() == KeyType.ReverseTab) {
+                    return Result.MOVE_FOCUS_PREVIOUS;
+                }
+            }
+            return Result.UNHANDLED;
+        }
+
+        @Override
+        public Interactable takeFocus() {
+            return this;
+        }
+
+        @Override
+        public void onEnterFocus(final FocusChangeDirection direction, final Interactable previouslyInFocus) {
+        }
+
+        @Override
+        public void onLeaveFocus(final FocusChangeDirection direction, final Interactable nextInFocus) {
+        }
+
+        @Override
+        public boolean isFocused() {
+            return true;
+        }
+
+        @Override
+        public Interactable setInputFilter(final InputFilter inputFilter) {
+            return this;
+        }
+
+        @Override
+        public InputFilter getInputFilter() {
+            return null;
+        }
+
+        @Override
+        public Interactable setEnabled(final boolean enabled) {
+            return this;
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return true;
+        }
+
+        @Override
+        public boolean isFocusable() {
+            return true;
+        }
+    }
+}

--- a/src/test/java/com/googlecode/lanterna/gui2/ScrollViewerTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/ScrollViewerTest.java
@@ -1,0 +1,81 @@
+package com.googlecode.lanterna.gui2;
+
+import com.googlecode.lanterna.TerminalPosition;
+import com.googlecode.lanterna.TerminalSize;
+import com.googlecode.lanterna.TextCharacter;
+import com.googlecode.lanterna.TextColor;
+import com.googlecode.lanterna.input.KeyStroke;
+
+import java.io.IOException;
+
+public class ScrollViewerTest extends TestBase {
+    public static void main(final String[] args) throws IOException, InterruptedException {
+        new ScrollViewerTest().run(args);
+    }
+
+    @Override
+    public void init(final WindowBasedTextGUI textGUI) {
+        final BasicWindow basicWindow = new BasicWindow("ScrollViewer test");
+        final Panel p = new Panel();
+
+        p.setPreferredSize(new TerminalSize(40, 24));
+
+        final ScrollViewer sv = new ScrollViewer();
+
+        sv.setComponent(new DumbComponent());
+
+        p.addComponent(sv);
+        basicWindow.setComponent(p);
+
+        textGUI.addWindow(basicWindow);
+    }
+
+    private final static class DumbComponent extends AbstractInteractableComponent<DumbComponent> {
+        @Override
+        protected Result handleKeyStroke(KeyStroke keyStroke) {
+            return Result.UNHANDLED;
+        }
+
+        @Override
+        protected InteractableRenderer<DumbComponent> createDefaultRenderer() {
+            return new InteractableRenderer<DumbComponent>() {
+                final TextColor BLACK = TextColor.Factory.fromString("#191919");
+                final TextColor WHITE = TextColor.ANSI.WHITE;
+
+                @Override
+                public TerminalPosition getCursorLocation(final DumbComponent c) {
+                    return null;
+                }
+
+                @Override
+                public TerminalSize getPreferredSize(final DumbComponent c) {
+                    return new TerminalSize(80, 40);
+                }
+
+                @Override
+                public void drawComponent(final TextGUIGraphics g, final DumbComponent c) {
+                    final int w = 80;
+                    final int h = 40;
+
+                    for (int x = 0; x < w; x += 6) {
+                        for (int y = 0; y < h; y ++) {
+                            final TextColor bg1 = y % 2 == 0 ? BLACK : WHITE;
+                            final TextColor bg2 = y % 2 == 0 ? WHITE : BLACK;
+
+                            g.fillRectangle(
+                                new TerminalPosition(x, y),
+                                new TerminalSize(3, 2),
+                                new TextCharacter(' ', WHITE, bg1)
+                            );
+                            g.fillRectangle(
+                                new TerminalPosition(x + 3, y),
+                                new TerminalSize(3, 2),
+                                new TextCharacter(' ', WHITE, bg2)
+                            );
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/src/test/java/com/googlecode/lanterna/gui2/ScrollViewerTest.java
+++ b/src/test/java/com/googlecode/lanterna/gui2/ScrollViewerTest.java
@@ -7,6 +7,7 @@ import com.googlecode.lanterna.TextColor;
 import com.googlecode.lanterna.input.KeyStroke;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 public class ScrollViewerTest extends TestBase {
     public static void main(final String[] args) throws IOException, InterruptedException {
@@ -15,10 +16,58 @@ public class ScrollViewerTest extends TestBase {
 
     @Override
     public void init(final WindowBasedTextGUI textGUI) {
-        final BasicWindow basicWindow = new BasicWindow("ScrollViewer test");
+        final BasicWindow selectorWindow = new BasicWindow("Select a Test");
+
+        selectorWindow.setComponent(
+            new ActionListBox().addItem(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        testCheckerboard(textGUI);
+                    }
+
+                    @Override
+                    public String toString() {
+                        return "Scrollbar policies";
+                    }
+                }
+            ).addItem(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        testFocusedComponentsScrolledIntoView(textGUI);
+                    }
+
+                    @Override
+                    public String toString() {
+                        return "Focused component scrolled into view";
+                    }
+                }
+            ).addItem(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        selectorWindow.close();
+                    }
+
+                    @Override
+                    public String toString() {
+                        return "Exit";
+                    }
+                }
+            )
+        );
+
+        textGUI.addWindow(selectorWindow);
+    }
+
+    private void testCheckerboard(final WindowBasedTextGUI textGUI) {
+        final BasicWindow basicWindow = new BasicWindow("Scrollbar Policy Test");
         final Panel p = new Panel();
 
-        p.setPreferredSize(new TerminalSize(40, 24));
+        basicWindow.setCloseWindowWithEscape(true);
+
+        p.setPreferredSize(new TerminalSize(40, 20));
 
         final ScrollViewer sv = new ScrollViewer();
 
@@ -28,8 +77,31 @@ public class ScrollViewerTest extends TestBase {
         basicWindow.setComponent(p);
 
         textGUI.addWindow(basicWindow);
+        basicWindow.setPosition(TerminalPosition.TOP_LEFT_CORNER);
     }
 
+    private void testFocusedComponentsScrolledIntoView(final WindowBasedTextGUI textGUI) {
+        final BasicWindow basicWindow = new BasicWindow("Bring Into View Test");
+        final Panel p1 = new Panel(new BorderLayout());
+        final Panel p2 = new Panel(new GridLayout(10).setHorizontalSpacing(6).setVerticalSpacing(3));
+        final ScrollViewer sv = new ScrollViewer();
+
+        basicWindow.setCloseWindowWithEscape(true);
+
+        for (int i = 1; i <= 10; i++) {
+            for (int j = 1; j <= 10; j++) {
+                p2.addComponent(new Button("(" + i + ", " + j + ")"));
+            }
+        }
+
+        p1.setPreferredSize(new TerminalSize(20, 10));
+        p1.addComponent(sv, BorderLayout.Location.CENTER);
+        sv.setComponent(p2);
+        basicWindow.setComponent(p1);
+
+        textGUI.addWindow(basicWindow);
+    }
+    
     private final static class DumbComponent extends AbstractInteractableComponent<DumbComponent> {
         @Override
         protected Result handleKeyStroke(KeyStroke keyStroke) {


### PR DESCRIPTION
I actually wrote this about eight years ago, but never got around to finishing it until your repo caught my eye in my starred list this weekend. If I recall, it's more or less complete. The only issue I could remember was that cursors would continue to paint even when their owner controls were scrolled out of view. I added a fix for that today.

I was able to build a really slick internal tool for inspecting a proprietary shared memory database with Lanterna at my last job, and I wanted to give something back. Hopefully you'll find it useful.

I'm sure there's a bug or two, but give it a go and see what you think. There's an interactive test/demo called `ScrollControllerTest` that lets you toggle content-assisted scrolling. It renders a checkerboard, and depending on whether the assist is enabled, it will either scroll normally by lines/columns or will snap to the squares' edges.

I'd wanted to include a proof-of-concept for hosting your `Table` where it would snap to column/row boundaries when scrolling, but I never got around to it.